### PR TITLE
chore: bump rocksdb crate version

### DIFF
--- a/collab-persistence/Cargo.toml
+++ b/collab-persistence/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 sled = { version = "0.34.7" }
-rocksdb = { version = "0.20.1", default-features = false, features = ["zstd"] }
+rocksdb = { version = "0.21.0", default-features = false, features = ["zstd"] }
 thiserror = "1.0.30"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3.3"


### PR DESCRIPTION
Fixes building rocksdb on certain machines, especially those using GCC13

ref: https://github.com/rust-rocksdb/rust-rocksdb/issues/772