### PR TITLE
feat: introduce per-view field settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,6 +675,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
+ "strum",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1288,6 +1289,12 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -2159,6 +2166,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2388,6 +2401,28 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.16",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,6 +676,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "strum",
+ "strum_macros",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2407,9 +2408,6 @@ name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
-dependencies = [
- "strum_macros",
-]
 
 [[package]]
 name = "strum_macros"

--- a/collab-database/Cargo.toml
+++ b/collab-database/Cargo.toml
@@ -26,7 +26,8 @@ async-trait = "0.1"
 uuid = { version = "1.3.3", features = ["v4", "v5"] }
 base64 = "^0.21"
 tokio-stream = { version = "0.1.14", features = ["sync"] }
-strum = { version = "0.25", features = ["derive"] }
+strum = "0.25"
+strum_macros = "0.25"
 
 [dev-dependencies]
 collab-plugins = { path = "../collab-plugins", features = ["rocksdb_plugin"] }

--- a/collab-database/Cargo.toml
+++ b/collab-database/Cargo.toml
@@ -26,6 +26,7 @@ async-trait = "0.1"
 uuid = { version = "1.3.3", features = ["v4", "v5"] }
 base64 = "^0.21"
 tokio-stream = { version = "0.1.14", features = ["sync"] }
+strum = { version = "0.25", features = ["derive"] }
 
 [dev-dependencies]
 collab-plugins = { path = "../collab-plugins", features = ["rocksdb_plugin"] }

--- a/collab-database/src/database.rs
+++ b/collab-database/src/database.rs
@@ -24,8 +24,8 @@ use crate::rows::{
 use crate::user::DatabaseCollabService;
 use crate::views::{
   CreateDatabaseParams, CreateViewParams, CreateViewParamsValidator, DatabaseLayout, DatabaseView,
-  FieldOrder, FieldSettings, FieldSettingsMap, FilterMap, GroupSettingMap, LayoutSetting, RowOrder,
-  SortMap, ViewDescription, ViewMap,
+  FieldOrder, FieldSettingsMap, FilterMap, GroupSettingMap, LayoutSetting, RowOrder, SortMap,
+  ViewDescription, ViewMap,
 };
 
 pub struct Database {
@@ -426,7 +426,7 @@ impl Database {
   pub fn create_field(
     &self,
     field: Field,
-    field_settings_by_layout: HashMap<DatabaseLayout, FieldSettings>,
+    field_settings_by_layout: HashMap<DatabaseLayout, FieldSettingsMap>,
   ) {
     self.root.with_transact_mut(|txn| {
       self.create_field_with_txn(txn, field, &field_settings_by_layout);
@@ -437,7 +437,7 @@ impl Database {
     &self,
     txn: &mut TransactionMut,
     field: Field,
-    field_settings_by_layout: &HashMap<DatabaseLayout, FieldSettings>,
+    field_settings_by_layout: &HashMap<DatabaseLayout, FieldSettingsMap>,
   ) {
     self.views.update_all_views_with_txn(txn, |update| {
       let field_id = field.id.clone();
@@ -462,7 +462,7 @@ impl Database {
     name: String,
     field_type: i64,
     f: impl FnOnce(&mut Field),
-    field_settings_by_layout: HashMap<DatabaseLayout, FieldSettings>,
+    field_settings_by_layout: HashMap<DatabaseLayout, FieldSettingsMap>,
   ) -> (usize, Field) {
     let mut field = Field::new(gen_field_id(), name, field_type, false);
     f(&mut field);
@@ -721,7 +721,7 @@ impl Database {
 
   /// Returns the field settings for the given field ids.
   /// If None, return field settings for all fields
-  pub fn get_field_settings<T: From<FieldSettings>>(
+  pub fn get_field_settings<T: From<FieldSettingsMap>>(
     &self,
     view_id: &str,
     field_ids: Option<Vec<String>>,
@@ -753,7 +753,7 @@ impl Database {
     &self,
     view_id: &str,
     field_ids: Option<Vec<String>>,
-    field_settings: impl Into<FieldSettings>,
+    field_settings: impl Into<FieldSettingsMap>,
   ) {
     let field_ids = field_ids.unwrap_or(
       self

--- a/collab-database/src/database.rs
+++ b/collab-database/src/database.rs
@@ -380,10 +380,6 @@ impl Database {
     self
       .fields
       .get_fields_with_txn(txn, field_ids)
-      .into_iter()
-      .collect::<Vec<Field>>()
-
-    // necessary?
   }
 
   /// Get all fields in the database

--- a/collab-database/src/database.rs
+++ b/collab-database/src/database.rs
@@ -425,7 +425,7 @@ impl Database {
       .collect()
   }
 
-  pub fn create_field(&self, field: Field, field_setting: impl Into<FieldSetting>) {
+  pub fn create_field(&self, field: Field, field_setting: FieldSetting) {
     self.root.with_transact_mut(|txn| {
       self.create_field_with_txn(txn, field, field_setting);
     })
@@ -435,11 +435,10 @@ impl Database {
     &self,
     txn: &mut TransactionMut,
     field: Field,
-    field_setting: impl Into<FieldSetting>,
+    field_setting: FieldSetting,
   ) {
-    let field_setting = field_setting.into();
-    self.views.update_all_views_with_txn(txn, |update| {
-      update.push_field_order(&field);
+    self.views.update_all_views_with_txn(txn, |mut update| {
+      update = update.push_field_order(&field);
       update.update_field_settings_one(field.id.as_str(), |field_setting_update| {
         field_setting_update.update(field.id.as_str(), |_| field_setting.clone());
       });
@@ -453,7 +452,7 @@ impl Database {
     name: String,
     field_type: i64,
     f: impl FnOnce(&mut Field),
-    field_setting: impl Into<FieldSetting>,
+    field_setting: FieldSetting,
   ) -> (usize, Field) {
     let mut field = Field::new(gen_field_id(), name, field_type, false);
     f(&mut field);
@@ -791,7 +790,7 @@ impl Database {
       let inline_view_id = self.get_inline_view_id_with_txn(txn);
       let row_orders = self.views.get_row_orders_with_txn(txn, &inline_view_id);
       let field_orders = self.views.get_field_orders_with_txn(txn, &inline_view_id);
-      let deps_fields = params.take_deps_fields();
+      let (deps_fields, deps_field_setting) = params.take_deps_fields();
 
       self.create_view_with_txn(txn, params, field_orders, row_orders)?;
 
@@ -799,7 +798,7 @@ impl Database {
       if !deps_fields.is_empty() {
         tracing::trace!("create linked view with deps fields: {:?}", deps_fields);
         deps_fields.into_iter().for_each(|field| {
-          self.create_field_with_txn(txn, field);
+          self.create_field_with_txn(txn, field, deps_field_setting.clone().unwrap());
         })
       }
       Ok::<(), DatabaseError>(())

--- a/collab-database/src/database.rs
+++ b/collab-database/src/database.rs
@@ -24,8 +24,8 @@ use crate::rows::{
 use crate::user::DatabaseCollabService;
 use crate::views::{
   CreateDatabaseParams, CreateViewParams, CreateViewParamsValidator, DatabaseLayout, DatabaseView,
-  FieldOrder, FieldSettingsMap, FilterMap, GroupSettingMap, LayoutSetting, RowOrder, SortMap,
-  ViewDescription, ViewMap,
+  FieldOrder, FieldSettingsByFieldIdMap, FieldSettingsMap, FilterMap, GroupSettingMap,
+  LayoutSetting, RowOrder, SortMap, ViewDescription, ViewMap,
 };
 
 pub struct Database {
@@ -67,6 +67,13 @@ impl Database {
 
     let row_orders = this.block.create_rows(rows);
     let field_orders = fields.iter().map(FieldOrder::from).collect();
+
+    // Create fieldSettingsByFieldIdMap from template FieldSettingsMap
+    let mut field_settings = FieldSettingsByFieldIdMap::new();
+    fields.iter().for_each(|field| {
+      field_settings.insert(field.id.clone(), params.field_settings.clone().into());
+    });
+
     this.root.with_transact_mut(|txn| {
       // Set the inline view id. The inline view id should not be
       // empty if the current database exists.
@@ -77,7 +84,7 @@ impl Database {
         this.fields.insert_field_with_txn(txn, field);
       }
       // Create a inline view
-      this.create_view_with_txn(txn, params, field_orders, row_orders)?;
+      this.create_view_with_txn(txn, params, field_settings, field_orders, row_orders)?;
       Ok::<(), DatabaseError>(())
     })?;
     Ok(this)
@@ -802,11 +809,16 @@ impl Database {
     let mut params = CreateViewParamsValidator::validate(params)?;
     self.root.with_transact_mut(|txn| {
       let inline_view_id = self.get_inline_view_id_with_txn(txn);
+      let fields = self.get_fields_with_txn(txn, None);
+      let mut field_settings = FieldSettingsByFieldIdMap::new();
+      fields.iter().for_each(|field| {
+        field_settings.insert(field.id.clone(), params.field_settings.clone().into());
+      });
       let row_orders = self.views.get_row_orders_with_txn(txn, &inline_view_id);
       let field_orders = self.views.get_field_orders_with_txn(txn, &inline_view_id);
       let (deps_fields, deps_field_setting) = params.take_deps_fields();
 
-      self.create_view_with_txn(txn, params, field_orders, row_orders)?;
+      self.create_view_with_txn(txn, params, field_settings, field_orders, row_orders)?;
 
       // After creating the view, we need to create the fields that are used in the view.
       if !deps_fields.is_empty() {
@@ -825,6 +837,7 @@ impl Database {
     &self,
     txn: &mut TransactionMut,
     params: CreateViewParams,
+    field_settings: FieldSettingsByFieldIdMap,
     field_orders: Vec<FieldOrder>,
     row_orders: Vec<RowOrder>,
   ) -> Result<(), DatabaseError> {
@@ -840,7 +853,7 @@ impl Database {
       filters: params.filters,
       group_settings: params.groups,
       sorts: params.sorts,
-      field_settings: params.field_settings,
+      field_settings,
       row_orders,
       field_orders,
       created_at: timestamp,

--- a/collab-database/src/views/field_settings.rs
+++ b/collab-database/src/views/field_settings.rs
@@ -1,0 +1,4 @@
+use collab::core::any_map::{AnyMap, AnyMapBuilder};
+
+pub type FieldSettingsMap = AnyMap;
+pub type FieldSettingsMapBuilder = AnyMapBuilder;

--- a/collab-database/src/views/field_settings.rs
+++ b/collab-database/src/views/field_settings.rs
@@ -1,5 +1,5 @@
 use collab::core::any_map::{AnyMap, AnyMapBuilder};
 
-pub type FieldSetting = AnyMap;
+pub type FieldSettings = AnyMap;
 pub type FieldSettingsMap = AnyMap;
 pub type FieldSettingsMapBuilder = AnyMapBuilder;

--- a/collab-database/src/views/field_settings.rs
+++ b/collab-database/src/views/field_settings.rs
@@ -1,4 +1,5 @@
 use collab::core::any_map::{AnyMap, AnyMapBuilder};
 
+pub type FieldSetting = AnyMap;
 pub type FieldSettingsMap = AnyMap;
 pub type FieldSettingsMapBuilder = AnyMapBuilder;

--- a/collab-database/src/views/field_settings.rs
+++ b/collab-database/src/views/field_settings.rs
@@ -1,5 +1,6 @@
 use collab::core::any_map::{AnyMap, AnyMapBuilder};
 
-pub type FieldSettings = AnyMap;
 pub type FieldSettingsMap = AnyMap;
 pub type FieldSettingsMapBuilder = AnyMapBuilder;
+pub type FieldSettingsByFieldIdMap = AnyMap;
+pub type FieldSettingsByFieldIdMapBuilder = AnyMapBuilder;

--- a/collab-database/src/views/layout.rs
+++ b/collab-database/src/views/layout.rs
@@ -51,30 +51,13 @@ impl Default for DatabaseLayout {
   }
 }
 
-impl TryFrom<i64> for DatabaseLayout {
-  type Error = anyhow::Error;
-
-  fn try_from(value: i64) -> std::result::Result<Self, Self::Error> {
+impl From<i64> for DatabaseLayout {
+  fn from(value: i64) -> Self {
     match value {
-      0 => Ok(DatabaseLayout::Grid),
-      1 => Ok(DatabaseLayout::Board),
-      2 => Ok(DatabaseLayout::Calendar),
-      _ => bail!("Unknown layout type {}", value),
-    }
-  }
-}
-
-impl From<lib0Any> for DatabaseLayout {
-  fn from(value: lib0Any) -> Self {
-    if let lib0Any::BigInt(layout_ty) = value {
-      match layout_ty {
-        0 => DatabaseLayout::Grid,
-        1 => DatabaseLayout::Board,
-        2 => DatabaseLayout::Calendar,
-        _ => Self::default(),
-      }
-    } else {
-      Self::default()
+      0 => DatabaseLayout::Grid,
+      1 => DatabaseLayout::Board,
+      2 => DatabaseLayout::Calendar,
+      _ => Self::default(),
     }
   }
 }

--- a/collab-database/src/views/layout.rs
+++ b/collab-database/src/views/layout.rs
@@ -64,6 +64,21 @@ impl TryFrom<i64> for DatabaseLayout {
   }
 }
 
+impl From<lib0Any> for DatabaseLayout {
+  fn from(value: lib0Any) -> Self {
+    if let lib0Any::BigInt(layout_ty) = value {
+      match layout_ty {
+        0 => DatabaseLayout::Grid,
+        1 => DatabaseLayout::Board,
+        2 => DatabaseLayout::Calendar,
+        _ => Self::default(),
+      }
+    } else {
+      Self::default()
+    }
+  }
+}
+
 impl From<DatabaseLayout> for lib0Any {
   fn from(layout: DatabaseLayout) -> Self {
     lib0Any::BigInt(layout as i64)

--- a/collab-database/src/views/layout.rs
+++ b/collab-database/src/views/layout.rs
@@ -3,12 +3,13 @@ use collab::core::any_map::{AnyMap, AnyMapBuilder};
 use collab::preclude::{lib0Any, Map, MapRef, MapRefExtension, ReadTxn, TransactionMut, YrsValue};
 use serde::{Deserialize, Serialize};
 use serde_repr::*;
+use strum::EnumIter;
 use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 
 /// The [DatabaseLayout] enum is used to represent the layout of the database.
-#[derive(Debug, PartialEq, Copy, Eq, Hash, Clone, Serialize_repr, Deserialize_repr)]
+#[derive(Debug, PartialEq, Copy, Eq, Hash, Clone, Serialize_repr, Deserialize_repr, EnumIter)]
 #[repr(u8)]
 pub enum DatabaseLayout {
   Grid = 0,

--- a/collab-database/src/views/layout.rs
+++ b/collab-database/src/views/layout.rs
@@ -3,10 +3,10 @@ use collab::core::any_map::{AnyMap, AnyMapBuilder};
 use collab::preclude::{lib0Any, Map, MapRef, MapRefExtension, ReadTxn, TransactionMut, YrsValue};
 use serde::{Deserialize, Serialize};
 use serde_repr::*;
-use strum::EnumIter;
 use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
+use strum_macros::EnumIter;
 
 /// The [DatabaseLayout] enum is used to represent the layout of the database.
 #[derive(Debug, PartialEq, Copy, Eq, Hash, Clone, Serialize_repr, Deserialize_repr, EnumIter)]

--- a/collab-database/src/views/mod.rs
+++ b/collab-database/src/views/mod.rs
@@ -1,4 +1,5 @@
 mod field_order;
+mod field_settings;
 mod filter;
 mod group;
 mod layout;
@@ -8,6 +9,7 @@ mod view;
 mod view_map;
 
 pub use field_order::*;
+pub use field_settings::*;
 pub use filter::*;
 pub use group::*;
 pub use layout::*;

--- a/collab-database/src/views/view.rs
+++ b/collab-database/src/views/view.rs
@@ -104,7 +104,11 @@ impl CreateViewParams {
     self
   }
 
-  pub fn with_deps_fields(mut self, fields: Vec<Field>, field_settings_by_layout: HashMap<DatabaseLayout, FieldSettingsMap>) -> Self {
+  pub fn with_deps_fields(
+    mut self,
+    fields: Vec<Field>,
+    field_settings_by_layout: HashMap<DatabaseLayout, FieldSettingsMap>,
+  ) -> Self {
     self.deps_fields = fields;
     self.deps_field_setting = field_settings_by_layout;
     self

--- a/collab-database/src/views/view.rs
+++ b/collab-database/src/views/view.rs
@@ -104,8 +104,9 @@ impl CreateViewParams {
     self
   }
 
-  pub fn with_deps_fields(mut self, fields: Vec<Field>) -> Self {
+  pub fn with_deps_fields(mut self, fields: Vec<Field>, field_settings_by_layout: HashMap<DatabaseLayout, FieldSettingsMap>) -> Self {
     self.deps_fields = fields;
+    self.deps_field_setting = field_settings_by_layout;
     self
   }
 }

--- a/collab-database/src/views/view.rs
+++ b/collab-database/src/views/view.rs
@@ -72,7 +72,13 @@ impl CreateViewParams {
 }
 
 impl CreateViewParams {
-  pub fn new(database_id: String, view_id: String, name: String, layout: DatabaseLayout, field_settings: FieldSettingsMap) -> Self {
+  pub fn new(
+    database_id: String,
+    view_id: String,
+    name: String,
+    layout: DatabaseLayout,
+    field_settings: FieldSettingsMap,
+  ) -> Self {
     Self {
       database_id,
       view_id,

--- a/collab-database/src/views/view.rs
+++ b/collab-database/src/views/view.rs
@@ -363,13 +363,13 @@ impl<'a, 'b> DatabaseViewUpdate<'a, 'b> {
   }
 
   /// Set the field settings of the current view
-  pub fn set_field_settings(mut self, field_id: &str, field_settings: FieldSettings) -> Self {
-    let map_ref = self.get_field_settings_for_field(field_id);
+  pub fn set_field_settings(mut self, field_settings: FieldSettingsMap) -> Self {
+    let map_ref = self.get_field_settings_map();
     field_settings.fill_map_ref(self.txn, &map_ref);
     self
   }
 
-  pub fn update_field_settings<F>(mut self, field_ids: Vec<String>, f: F) -> Self
+  pub fn update_field_settings_for_fields<F>(mut self, field_ids: Vec<String>, f: F) -> Self
   where
     F: Fn(&str, AnyMapUpdate),
   {
@@ -378,16 +378,6 @@ impl<'a, 'b> DatabaseViewUpdate<'a, 'b> {
       let update = AnyMapUpdate::new(self.txn, &map_ref);
       f(field_id.as_str(), update);
     });
-    self
-  }
-
-  pub fn update_field_settings_for_field<F>(mut self, field_id: &str, f: F) -> Self
-  where
-    F: FnOnce(AnyMapUpdate),
-  {
-    let map_ref = self.get_field_settings_for_field(field_id);
-    let update = AnyMapUpdate::new(self.txn, &map_ref);
-    f(update);
     self
   }
 
@@ -427,15 +417,6 @@ impl<'a, 'b> DatabaseViewUpdate<'a, 'b> {
     self
       .map_ref
       .get_or_insert_map_with_txn(self.txn, VIEW_FIELD_SETTINGS)
-  }
-
-  /// Get the field settings for one field in the curent view, used when setting
-  /// or updating the field setting
-  fn get_field_settings_for_field(&mut self, field_id: &str) -> MapRef {
-    self
-      .map_ref
-      .get_or_insert_map_with_txn(self.txn, VIEW_FIELD_SETTINGS)
-      .get_or_insert_map_with_txn(self.txn, field_id)
   }
 
   pub fn done(self) -> Option<DatabaseView> {

--- a/collab-database/src/views/view.rs
+++ b/collab-database/src/views/view.rs
@@ -72,12 +72,13 @@ impl CreateViewParams {
 }
 
 impl CreateViewParams {
-  pub fn new(database_id: String, view_id: String, name: String, layout: DatabaseLayout) -> Self {
+  pub fn new(database_id: String, view_id: String, name: String, layout: DatabaseLayout, field_settings: FieldSettingsMap) -> Self {
     Self {
       database_id,
       view_id,
       name,
       layout,
+      field_settings,
       ..Default::default()
     }
   }

--- a/collab-database/src/views/view.rs
+++ b/collab-database/src/views/view.rs
@@ -14,8 +14,8 @@ use crate::fields::Field;
 use crate::rows::CreateRowParams;
 use crate::views::layout::{DatabaseLayout, LayoutSettings};
 use crate::views::{
-  FieldOrder, FieldOrderArray, FieldSettingsMap, FilterArray, FilterMap, GroupSettingArray,
-  GroupSettingMap, LayoutSetting, RowOrder, RowOrderArray, SortArray, SortMap,
+  FieldOrder, FieldOrderArray, FieldSettingsByFieldIdMap, FieldSettingsMap, FilterArray, FilterMap,
+  GroupSettingArray, GroupSettingMap, LayoutSetting, RowOrder, RowOrderArray, SortArray, SortMap,
 };
 use crate::{impl_any_update, impl_i64_update, impl_order_update, impl_str_update};
 
@@ -31,7 +31,7 @@ pub struct DatabaseView {
   pub sorts: Vec<SortMap>,
   pub row_orders: Vec<RowOrder>,
   pub field_orders: Vec<FieldOrder>,
-  pub field_settings: FieldSettingsMap,
+  pub field_settings: FieldSettingsByFieldIdMap,
   pub created_at: i64,
   pub modified_at: i64,
 }

--- a/collab-database/src/views/view_map.rs
+++ b/collab-database/src/views/view_map.rs
@@ -11,8 +11,6 @@ use crate::views::{
   ROW_ORDERS, VIEW_LAYOUT,
 };
 
-use super::layout;
-
 pub struct ViewMap {
   container: MapRefWrapper,
 }

--- a/collab-database/src/views/view_map.rs
+++ b/collab-database/src/views/view_map.rs
@@ -37,6 +37,7 @@ impl ViewMap {
         .set_database_id(view.database_id)
         .set_layout_settings(view.layout_settings)
         .set_layout_type(view.layout)
+        .set_field_settings(view.field_settings)
         .set_filters(view.filters)
         .set_groups(view.group_settings)
         .set_sorts(view.sorts)

--- a/collab-database/src/views/view_map.rs
+++ b/collab-database/src/views/view_map.rs
@@ -3,11 +3,12 @@ use collab::preclude::{Map, MapRef, MapRefExtension, MapRefWrapper, ReadTxn, Tra
 use crate::database::timestamp;
 use crate::rows::RowId;
 use crate::views::{
-  filters_from_map_ref, group_setting_from_map_ref, layout_setting_from_map_ref,
-  sorts_from_map_ref, view_description_from_value, view_from_map_ref, view_from_value,
-  view_id_from_map_ref, DatabaseLayout, DatabaseView, DatabaseViewUpdate, FieldOrder,
-  FieldOrderArray, FilterMap, GroupSettingMap, LayoutSetting, OrderArray, RowOrder, RowOrderArray,
-  SortMap, ViewBuilder, ViewDescription, FIELD_ORDERS, ROW_ORDERS, VIEW_LAYOUT,
+  field_settings_from_map_ref, filters_from_map_ref, group_setting_from_map_ref,
+  layout_setting_from_map_ref, sorts_from_map_ref, view_description_from_value, view_from_map_ref,
+  view_from_value, view_id_from_map_ref, DatabaseLayout, DatabaseView, DatabaseViewUpdate,
+  FieldOrder, FieldOrderArray, FieldSettingsMap, FilterMap, GroupSettingMap, LayoutSetting,
+  OrderArray, RowOrder, RowOrderArray, SortMap, ViewBuilder, ViewDescription, FIELD_ORDERS,
+  ROW_ORDERS, VIEW_LAYOUT,
 };
 
 pub struct ViewMap {
@@ -73,6 +74,7 @@ impl ViewMap {
       vec![]
     }
   }
+
   pub fn get_view_filters(&self, view_id: &str) -> Vec<FilterMap> {
     let txn = self.container.transact();
     self.get_view_filters_with_txn(&txn, view_id)
@@ -99,6 +101,15 @@ impl ViewMap {
     } else {
       None
     }
+  }
+
+  pub fn get_view_field_settings(&self, view_id: &str) -> FieldSettingsMap {
+    let txn = self.container.transact();
+    self
+      .container
+      .get_map_with_txn(&txn, view_id)
+      .map(|map_ref| field_settings_from_map_ref(&txn, &map_ref))
+      .unwrap_or_default()
   }
 
   pub fn get_view(&self, view_id: &str) -> Option<DatabaseView> {
@@ -176,7 +187,7 @@ impl ViewMap {
     f().is_some()
   }
 
-  pub fn get_field_orders_txn<T: ReadTxn>(&self, txn: &T, view_id: &str) -> Vec<FieldOrder> {
+  pub fn get_field_orders_with_txn<T: ReadTxn>(&self, txn: &T, view_id: &str) -> Vec<FieldOrder> {
     self
       .container
       .get_map_with_txn(txn, view_id)

--- a/collab-database/src/views/view_map.rs
+++ b/collab-database/src/views/view_map.rs
@@ -11,6 +11,8 @@ use crate::views::{
   ROW_ORDERS, VIEW_LAYOUT,
 };
 
+use super::layout;
+
 pub struct ViewMap {
   container: MapRefWrapper,
 }

--- a/collab-database/tests/database_test/field_setting_test.rs
+++ b/collab-database/tests/database_test/field_setting_test.rs
@@ -14,10 +14,10 @@ async fn new_field_new_field_setting_test() {
   let params = CreateViewParams {
     database_id: "1".to_string(),
     view_id: "v2".to_string(),
+    field_settings: field_settings_for_default_database(),
     ..Default::default()
   };
   database_test.create_linked_view(params).unwrap();
-  database_test.set_field_settings("v2", field_settings_for_default_database());
 
   // Create a new field
   database_test.create_field(
@@ -40,10 +40,10 @@ async fn remove_field_remove_field_setting_test() {
   let params = CreateViewParams {
     database_id: "1".to_string(),
     view_id: "v2".to_string(),
+    field_settings: field_settings_for_default_database(),
     ..Default::default()
   };
   database_test.create_linked_view(params).unwrap();
-  database_test.set_field_settings("v2", field_settings_for_default_database());
 
   // Delete a field
   database_test.delete_field("f3");
@@ -64,10 +64,10 @@ async fn update_field_setting_for_some_fields_test() {
   let params = CreateViewParams {
     database_id: "1".to_string(),
     view_id: "v2".to_string(),
+    field_settings: field_settings_for_default_database(),
     ..Default::default()
   };
   database_test.create_linked_view(params).unwrap();
-  database_test.set_field_settings("v2", field_settings_for_default_database());
 
   // Update field settings for one field
   database_test.update_field_settings("v1", Some(vec!["f1".to_string()]), field_settings.clone());
@@ -128,7 +128,7 @@ async fn duplicate_view_duplicates_field_settings_test() {
     database_test.get_field_settings(&duplicate_view.id, None);
   let test_field_settings = field_settings_map.get("f1").unwrap();
   assert_eq!(field_settings_map.len(), 3);
-  assert!(test_field_settings.to_owned().is_visible);
+  assert!(!test_field_settings.to_owned().is_visible);
 }
 
 #[tokio::test]
@@ -138,6 +138,8 @@ async fn new_view_requires_deps_field_test() {
   let params = CreateViewParams {
     database_id: "1".to_string(),
     view_id: "v2".to_string(),
+    layout: DatabaseLayout::Calendar,
+    field_settings: field_settings_for_default_database(),
     deps_fields: vec![deps_field],
     deps_field_setting: default_field_settings_map(),
     ..Default::default()
@@ -147,14 +149,16 @@ async fn new_view_requires_deps_field_test() {
   // on v1, the new field should be created
   let field_settings_map: HashMap<String, TestFieldSetting> =
     database_test.get_field_settings("v1", None);
-  let test_field_settings = field_settings_map.get("f1").unwrap();
+  let test_field_settings = field_settings_map.get("f4").unwrap();
   assert_eq!(field_settings_map.len(), 4);
   assert!(test_field_settings.to_owned().is_visible);
 
   // on v2, the new field should also be created and is invisible
-  let field_settings: HashMap<String, TestFieldSetting> =
+  let field_settings_map: HashMap<String, TestFieldSetting> =
     database_test.get_field_settings("v2", None);
-  assert_eq!(field_settings.len(), 4);
+  let test_field_settings = field_settings_map.get("f4").unwrap();
+  println!("asdfasdf {:?}", field_settings_map);
+  assert_eq!(field_settings_map.len(), 4);
   assert!(!test_field_settings.to_owned().is_visible);
 }
 

--- a/collab-database/tests/database_test/field_setting_test.rs
+++ b/collab-database/tests/database_test/field_setting_test.rs
@@ -1,0 +1,7 @@
+/*
+  1. default field settings across different layout types
+  2. insert new field, new field settings should be inserted
+  3. remove existing field, field settings should be removed
+  4. update field settings for some fields
+  5. update field settings for all fields
+*/

--- a/collab-database/tests/database_test/field_setting_test.rs
+++ b/collab-database/tests/database_test/field_setting_test.rs
@@ -9,6 +9,7 @@ use crate::database_test::helper::{
 
 #[tokio::test]
 async fn new_field_new_field_setting_test() {
+  // TODO: create a new view as well
   let database_test = create_database_with_default_data(1, "1");
   let field_setting = TestFieldSetting::new();
   database_test.create_field(
@@ -16,31 +17,29 @@ async fn new_field_new_field_setting_test() {
     field_setting.into(),
   );
 
-  let field_settings: HashMap<String, TestFieldSetting> =
+  let field_settings_map: HashMap<String, TestFieldSetting> =
     database_test.get_field_settings("v1", None);
-  assert_eq!(field_settings.len(), 4);
-  assert!(TestFieldSetting::from(field_settings.get("f4").unwrap().to_owned()).is_visible);
+  assert_eq!(field_settings_map.len(), 4);
+
+  let field_settings = field_settings_map.get("f4").unwrap().to_owned();
+  assert!(TestFieldSetting::from(field_settings).is_visible);
 }
 
-// #[tokio::test]
-// async fn remove_field_remove_field_setting_test() {
-//   let database_test = create_database_with_default_data(1, "1");
-//   database_test.create_field(Field::new(
-//     "f4".to_string(),
-//     "text field".to_string(),
-//     0,
-//     true,
-//   ));
+#[tokio::test]
+async fn remove_field_remove_field_setting_test() {
+  // TODO: create a new view as well
+  let database_test = create_database_with_default_data(1, "1");
+  database_test.delete_field("f3");
 
-//   let field_settings: HashMap<String, TestFieldSetting> =
-//     database_test.get_field_settings("v1", None);
-//   assert_eq!(field_settings.len(), 2);
-// }
+  let field_settings: HashMap<String, TestFieldSetting> =
+    database_test.get_field_settings("v1", None);
+  assert_eq!(field_settings.len(), 2);
+}
 
 // #[tokio::test]
 // async fn update_field_setting_for_some_fields_test() {
 //   let database_test = create_database_with_default_data(1, "1");
-//   database_test.create_field(Field::new(
+//   database_test.update_field_settings(Field::new(
 //     "f4".to_string(),
 //     "text field".to_string(),
 //     0,
@@ -100,3 +99,7 @@ async fn new_field_new_field_setting_test() {
 // // duplicate a view, the field settings should be copied over
 
 // // create a new view with a non-default field settings
+
+// create a new view, different field setting for different layout type
+
+// remove a field

--- a/collab-database/tests/database_test/field_setting_test.rs
+++ b/collab-database/tests/database_test/field_setting_test.rs
@@ -1,7 +1,108 @@
-/*
-  1. default field settings across different layout types
-  2. insert new field, new field settings should be inserted
-  3. remove existing field, field settings should be removed
-  4. update field settings for some fields
-  5. update field settings for all fields
-*/
+use std::collections::HashMap;
+
+use collab_database::fields::Field;
+use collab_database::views::CreateViewParams;
+
+use crate::database_test::helper::{
+  create_database, create_database_with_default_data, TestFieldSetting,
+};
+
+#[tokio::test]
+async fn new_field_new_field_setting_test() {
+  let database_test = create_database_with_default_data(1, "1");
+  database_test.create_field(Field::new(
+    "f4".to_string(),
+    "text field".to_string(),
+    0,
+    true,
+  ));
+
+  let field_settings: HashMap<String, TestFieldSetting> =
+    database_test.get_field_settings("v1", None);
+  assert_eq!(field_settings.len(), 4);
+
+  // let fields = database_test.fields.get_all_fields();
+  // assert_eq!(fields.len(), 1);
+
+  // let view = database_test.views.get_view("v1").unwrap();
+  // assert_eq!(view.field_orders[0].id, fields[0].id);
+}
+
+#[tokio::test]
+async fn remove_field_remove_field_setting_test() {
+  let database_test = create_database_with_default_data(1, "1");
+  database_test.create_field(Field::new(
+    "f4".to_string(),
+    "text field".to_string(),
+    0,
+    true,
+  ));
+
+  let field_settings: HashMap<String, TestFieldSetting> =
+    database_test.get_field_settings("v1", None);
+  assert_eq!(field_settings.len(), 2);
+}
+
+#[tokio::test]
+async fn update_field_setting_for_some_fields_test() {
+  let database_test = create_database_with_default_data(1, "1");
+  database_test.create_field(Field::new(
+    "f4".to_string(),
+    "text field".to_string(),
+    0,
+    true,
+  ));
+
+  let field_settings: HashMap<String, TestFieldSetting> =
+    database_test.get_field_settings("v1", None);
+  assert_eq!(field_settings.len(), 2);
+}
+
+#[tokio::test]
+async fn update_field_setting_for_all_fields_test() {
+  let database_test = create_database_with_default_data(1, "1");
+  database_test.create_field(Field::new(
+    "f4".to_string(),
+    "text field".to_string(),
+    0,
+    true,
+  ));
+
+  let field_settings: HashMap<String, TestFieldSetting> =
+    database_test.get_field_settings("v1", None);
+  assert_eq!(field_settings.len(), 2);
+}
+
+#[tokio::test]
+async fn new_view_new_field_setting_map_test() {
+  let database_test = create_database_with_default_data(1, "1");
+  database_test.create_field(Field::new(
+    "f4".to_string(),
+    "text field".to_string(),
+    0,
+    true,
+  ));
+
+  let field_settings: HashMap<String, TestFieldSetting> =
+    database_test.get_field_settings("v1", None);
+  assert_eq!(field_settings.len(), 2);
+}
+
+#[tokio::test]
+async fn new_view_new_field_setting_map_test() {
+  let database_test = create_database_with_default_data(1, "1");
+  database_test.create_field(Field::new(
+    "f4".to_string(),
+    "text field".to_string(),
+    0,
+    true,
+  ));
+
+  let field_settings: HashMap<String, TestFieldSetting> =
+    database_test.get_field_settings("v1", None);
+  assert_eq!(field_settings.len(), 2);
+}
+
+// duplicate a view, the field settings should be copied over
+
+// create a new view with a non-default field settings

--- a/collab-database/tests/database_test/field_setting_test.rs
+++ b/collab-database/tests/database_test/field_setting_test.rs
@@ -1,16 +1,16 @@
 use std::collections::HashMap;
 
 use collab_database::fields::Field;
-use collab_database::views::{CreateViewParams, DatabaseLayout, FieldSettings};
+use collab_database::views::{CreateViewParams, DatabaseLayout};
 
 use crate::database_test::helper::{
-  create_database_with_default_data, field_settings_for_default_database, TestFieldSetting,
+  create_database_with_default_data, default_field_settings_by_layout,
+  field_settings_for_default_database, TestFieldSetting,
 };
 
 #[tokio::test]
 async fn new_field_new_field_setting_test() {
   let database_test = create_database_with_default_data(1, "1");
-  let field_setting = TestFieldSetting::new();
   let params = CreateViewParams {
     database_id: "1".to_string(),
     view_id: "v2".to_string(),
@@ -22,7 +22,7 @@ async fn new_field_new_field_setting_test() {
   // Create a new field
   database_test.create_field(
     Field::new("f4".to_string(), "text field".to_string(), 0, true),
-    field_setting.into(),
+    default_field_settings_by_layout(),
   );
 
   let field_settings_map: HashMap<String, TestFieldSetting> =
@@ -141,7 +141,7 @@ async fn new_view_requires_deps_field_test() {
     layout: DatabaseLayout::Calendar,
     field_settings: field_settings_for_default_database(),
     deps_fields: vec![deps_field],
-    deps_field_setting: default_field_settings_map(),
+    deps_field_setting: default_field_settings_by_layout(),
     ..Default::default()
   };
   database_test.create_linked_view(params).unwrap();
@@ -160,16 +160,4 @@ async fn new_view_requires_deps_field_test() {
   println!("asdfasdf {:?}", field_settings_map);
   assert_eq!(field_settings_map.len(), 4);
   assert!(!test_field_settings.to_owned().is_visible);
-}
-
-fn default_field_settings_map() -> HashMap<DatabaseLayout, FieldSettings> {
-  let field_settings = TestFieldSetting { is_visible: true };
-  HashMap::from([
-    (DatabaseLayout::Grid, field_settings.clone().into()),
-    (DatabaseLayout::Board, field_settings.into()),
-    (
-      DatabaseLayout::Calendar,
-      TestFieldSetting { is_visible: false }.into(),
-    ),
-  ])
 }

--- a/collab-database/tests/database_test/field_setting_test.rs
+++ b/collab-database/tests/database_test/field_setting_test.rs
@@ -1,17 +1,25 @@
 use std::collections::HashMap;
 
 use collab_database::fields::Field;
-use collab_database::views::CreateViewParams;
+use collab_database::views::{CreateViewParams, DatabaseLayout, FieldSettings};
 
 use crate::database_test::helper::{
-  create_database, create_database_with_default_data, TestFieldSetting,
+  create_database_with_default_data, field_settings_for_default_database, TestFieldSetting,
 };
 
 #[tokio::test]
 async fn new_field_new_field_setting_test() {
-  // TODO: create a new view as well
   let database_test = create_database_with_default_data(1, "1");
   let field_setting = TestFieldSetting::new();
+  let params = CreateViewParams {
+    database_id: "1".to_string(),
+    view_id: "v2".to_string(),
+    ..Default::default()
+  };
+  database_test.create_linked_view(params).unwrap();
+  database_test.set_field_settings("v2", field_settings_for_default_database());
+
+  // Create a new field
   database_test.create_field(
     Field::new("f4".to_string(), "text field".to_string(), 0, true),
     field_setting.into(),
@@ -21,85 +29,143 @@ async fn new_field_new_field_setting_test() {
     database_test.get_field_settings("v1", None);
   assert_eq!(field_settings_map.len(), 4);
 
-  let field_settings = field_settings_map.get("f4").unwrap().to_owned();
-  assert!(TestFieldSetting::from(field_settings).is_visible);
+  let field_settings_map: HashMap<String, TestFieldSetting> =
+    database_test.get_field_settings("v2", None);
+  assert_eq!(field_settings_map.len(), 4);
 }
 
 #[tokio::test]
 async fn remove_field_remove_field_setting_test() {
-  // TODO: create a new view as well
   let database_test = create_database_with_default_data(1, "1");
+  let params = CreateViewParams {
+    database_id: "1".to_string(),
+    view_id: "v2".to_string(),
+    ..Default::default()
+  };
+  database_test.create_linked_view(params).unwrap();
+  database_test.set_field_settings("v2", field_settings_for_default_database());
+
+  // Delete a field
   database_test.delete_field("f3");
 
-  let field_settings: HashMap<String, TestFieldSetting> =
+  let field_settings_map: HashMap<String, TestFieldSetting> =
     database_test.get_field_settings("v1", None);
-  assert_eq!(field_settings.len(), 2);
+  assert_eq!(field_settings_map.len(), 2);
+
+  let field_settings_map: HashMap<String, TestFieldSetting> =
+    database_test.get_field_settings("v2", None);
+  assert_eq!(field_settings_map.len(), 2);
 }
 
-// #[tokio::test]
-// async fn update_field_setting_for_some_fields_test() {
-//   let database_test = create_database_with_default_data(1, "1");
-//   database_test.update_field_settings(Field::new(
-//     "f4".to_string(),
-//     "text field".to_string(),
-//     0,
-//     true,
-//   ));
+#[tokio::test]
+async fn update_field_setting_for_some_fields_test() {
+  let database_test = create_database_with_default_data(1, "1");
+  let field_settings = TestFieldSetting { is_visible: false };
+  let params = CreateViewParams {
+    database_id: "1".to_string(),
+    view_id: "v2".to_string(),
+    ..Default::default()
+  };
+  database_test.create_linked_view(params).unwrap();
+  database_test.set_field_settings("v2", field_settings_for_default_database());
 
-//   let field_settings: HashMap<String, TestFieldSetting> =
-//     database_test.get_field_settings("v1", None);
-//   assert_eq!(field_settings.len(), 2);
-// }
+  // Update field settings for one field
+  database_test.update_field_settings("v1", Some(vec!["f1".to_string()]), field_settings.clone());
 
-// #[tokio::test]
-// async fn update_field_setting_for_all_fields_test() {
-//   let database_test = create_database_with_default_data(1, "1");
-//   database_test.create_field(Field::new(
-//     "f4".to_string(),
-//     "text field".to_string(),
-//     0,
-//     true,
-//   ));
+  // on v1, the field settings for f1 should change
+  let field_settings_map: HashMap<String, TestFieldSetting> =
+    database_test.get_field_settings("v1", None);
+  let test_field_settings = field_settings_map.get("f1").unwrap();
+  assert!(!test_field_settings.to_owned().is_visible);
 
-//   let field_settings: HashMap<String, TestFieldSetting> =
-//     database_test.get_field_settings("v1", None);
-//   assert_eq!(field_settings.len(), 2);
-// }
+  // on v2, the field settings for f1 should stay the same
+  let field_settings_map: HashMap<String, TestFieldSetting> =
+    database_test.get_field_settings("v2", None);
+  let test_field_settings = field_settings_map.get("f1").unwrap();
+  assert!(test_field_settings.to_owned().is_visible);
 
-// #[tokio::test]
-// async fn new_view_new_field_setting_map_test() {
-//   let database_test = create_database_with_default_data(1, "1");
-//   database_test.create_field(Field::new(
-//     "f4".to_string(),
-//     "text field".to_string(),
-//     0,
-//     true,
-//   ));
+  // Update field settings for all fields
+  database_test.update_field_settings("v1", None, field_settings);
 
-//   let field_settings: HashMap<String, TestFieldSetting> =
-//     database_test.get_field_settings("v1", None);
-//   assert_eq!(field_settings.len(), 2);
-// }
+  // All fields in v1 should be invisible
+  let field_settings_map: HashMap<String, TestFieldSetting> =
+    database_test.get_field_settings("v1", None);
+  field_settings_map
+    .into_iter()
+    .for_each(|(_field_id, test_field_settings)| {
+      assert!(!test_field_settings.to_owned().is_visible);
+    });
 
-// #[tokio::test]
-// async fn new_view_new_field_setting_map_test() {
-//   let database_test = create_database_with_default_data(1, "1");
-//   database_test.create_field(Field::new(
-//     "f4".to_string(),
-//     "text field".to_string(),
-//     0,
-//     true,
-//   ));
+  // All fields in v2 should still be visible
+  let field_settings_map: HashMap<String, TestFieldSetting> =
+    database_test.get_field_settings("v2", None);
+  field_settings_map
+    .into_iter()
+    .for_each(|(_field_id, test_field_settings)| {
+      assert!(test_field_settings.to_owned().is_visible);
+    });
+}
 
-//   let field_settings: HashMap<String, TestFieldSetting> =
-//     database_test.get_field_settings("v1", None);
-//   assert_eq!(field_settings.len(), 2);
-// }
+#[tokio::test]
+async fn duplicate_view_duplicates_field_settings_test() {
+  let database_test = create_database_with_default_data(1, "1");
+  let field_settings = TestFieldSetting { is_visible: false };
 
-// // duplicate a view, the field settings should be copied over
+  // Update field settings for one field
+  database_test.update_field_settings("v1", Some(vec!["f1".to_string()]), field_settings.clone());
 
-// // create a new view with a non-default field settings
+  // the field settings for f1 should change
+  let field_settings_map: HashMap<String, TestFieldSetting> =
+    database_test.get_field_settings("v1", None);
+  let test_field_settings = field_settings_map.get("f1").unwrap();
+  assert!(!test_field_settings.to_owned().is_visible);
 
-// create a new view, different field setting for different layout type
+  // duplicate view v1
+  let duplicate_view = database_test.duplicate_linked_view("v1").unwrap();
 
-// remove a field
+  // on the duplicate view, the field settings for f1 should be the same
+  let field_settings_map: HashMap<String, TestFieldSetting> =
+    database_test.get_field_settings(&duplicate_view.id, None);
+  let test_field_settings = field_settings_map.get("f1").unwrap();
+  assert_eq!(field_settings_map.len(), 3);
+  assert!(test_field_settings.to_owned().is_visible);
+}
+
+#[tokio::test]
+async fn new_view_requires_deps_field_test() {
+  let database_test = create_database_with_default_data(1, "1");
+  let deps_field = Field::new("f4".to_string(), "date".to_string(), 3, false);
+  let params = CreateViewParams {
+    database_id: "1".to_string(),
+    view_id: "v2".to_string(),
+    deps_fields: vec![deps_field],
+    deps_field_setting: default_field_settings_map(),
+    ..Default::default()
+  };
+  database_test.create_linked_view(params).unwrap();
+
+  // on v1, the new field should be created
+  let field_settings_map: HashMap<String, TestFieldSetting> =
+    database_test.get_field_settings("v1", None);
+  let test_field_settings = field_settings_map.get("f1").unwrap();
+  assert_eq!(field_settings_map.len(), 4);
+  assert!(test_field_settings.to_owned().is_visible);
+
+  // on v2, the new field should also be created and is invisible
+  let field_settings: HashMap<String, TestFieldSetting> =
+    database_test.get_field_settings("v2", None);
+  assert_eq!(field_settings.len(), 4);
+  assert!(!test_field_settings.to_owned().is_visible);
+}
+
+fn default_field_settings_map() -> HashMap<DatabaseLayout, FieldSettings> {
+  let field_settings = TestFieldSetting { is_visible: true };
+  HashMap::from([
+    (DatabaseLayout::Grid, field_settings.clone().into()),
+    (DatabaseLayout::Board, field_settings.into()),
+    (
+      DatabaseLayout::Calendar,
+      TestFieldSetting { is_visible: false }.into(),
+    ),
+  ])
+}

--- a/collab-database/tests/database_test/field_setting_test.rs
+++ b/collab-database/tests/database_test/field_setting_test.rs
@@ -93,7 +93,7 @@ async fn update_field_setting_for_some_fields_test() {
   field_settings_map
     .into_iter()
     .for_each(|(_field_id, test_field_settings)| {
-      assert!(!test_field_settings.to_owned().is_visible);
+      assert!(!test_field_settings.is_visible);
     });
 
   // All fields in v2 should still be visible
@@ -102,7 +102,7 @@ async fn update_field_setting_for_some_fields_test() {
   field_settings_map
     .into_iter()
     .for_each(|(_field_id, test_field_settings)| {
-      assert!(test_field_settings.to_owned().is_visible);
+      assert!(test_field_settings.is_visible);
     });
 }
 
@@ -112,7 +112,7 @@ async fn duplicate_view_duplicates_field_settings_test() {
   let field_settings = TestFieldSetting { is_visible: false };
 
   // Update field settings for one field
-  database_test.update_field_settings("v1", Some(vec!["f1".to_string()]), field_settings.clone());
+  database_test.update_field_settings("v1", Some(vec!["f1".to_string()]), field_settings);
 
   // the field settings for f1 should change
   let field_settings_map: HashMap<String, TestFieldSetting> =

--- a/collab-database/tests/database_test/field_setting_test.rs
+++ b/collab-database/tests/database_test/field_setting_test.rs
@@ -10,99 +10,93 @@ use crate::database_test::helper::{
 #[tokio::test]
 async fn new_field_new_field_setting_test() {
   let database_test = create_database_with_default_data(1, "1");
-  database_test.create_field(Field::new(
-    "f4".to_string(),
-    "text field".to_string(),
-    0,
-    true,
-  ));
+  let field_setting = TestFieldSetting::new();
+  database_test.create_field(
+    Field::new("f4".to_string(), "text field".to_string(), 0, true),
+    field_setting.into(),
+  );
 
   let field_settings: HashMap<String, TestFieldSetting> =
     database_test.get_field_settings("v1", None);
   assert_eq!(field_settings.len(), 4);
-
-  // let fields = database_test.fields.get_all_fields();
-  // assert_eq!(fields.len(), 1);
-
-  // let view = database_test.views.get_view("v1").unwrap();
-  // assert_eq!(view.field_orders[0].id, fields[0].id);
+  assert!(TestFieldSetting::from(field_settings.get("f4").unwrap().to_owned()).is_visible);
 }
 
-#[tokio::test]
-async fn remove_field_remove_field_setting_test() {
-  let database_test = create_database_with_default_data(1, "1");
-  database_test.create_field(Field::new(
-    "f4".to_string(),
-    "text field".to_string(),
-    0,
-    true,
-  ));
+// #[tokio::test]
+// async fn remove_field_remove_field_setting_test() {
+//   let database_test = create_database_with_default_data(1, "1");
+//   database_test.create_field(Field::new(
+//     "f4".to_string(),
+//     "text field".to_string(),
+//     0,
+//     true,
+//   ));
 
-  let field_settings: HashMap<String, TestFieldSetting> =
-    database_test.get_field_settings("v1", None);
-  assert_eq!(field_settings.len(), 2);
-}
+//   let field_settings: HashMap<String, TestFieldSetting> =
+//     database_test.get_field_settings("v1", None);
+//   assert_eq!(field_settings.len(), 2);
+// }
 
-#[tokio::test]
-async fn update_field_setting_for_some_fields_test() {
-  let database_test = create_database_with_default_data(1, "1");
-  database_test.create_field(Field::new(
-    "f4".to_string(),
-    "text field".to_string(),
-    0,
-    true,
-  ));
+// #[tokio::test]
+// async fn update_field_setting_for_some_fields_test() {
+//   let database_test = create_database_with_default_data(1, "1");
+//   database_test.create_field(Field::new(
+//     "f4".to_string(),
+//     "text field".to_string(),
+//     0,
+//     true,
+//   ));
 
-  let field_settings: HashMap<String, TestFieldSetting> =
-    database_test.get_field_settings("v1", None);
-  assert_eq!(field_settings.len(), 2);
-}
+//   let field_settings: HashMap<String, TestFieldSetting> =
+//     database_test.get_field_settings("v1", None);
+//   assert_eq!(field_settings.len(), 2);
+// }
 
-#[tokio::test]
-async fn update_field_setting_for_all_fields_test() {
-  let database_test = create_database_with_default_data(1, "1");
-  database_test.create_field(Field::new(
-    "f4".to_string(),
-    "text field".to_string(),
-    0,
-    true,
-  ));
+// #[tokio::test]
+// async fn update_field_setting_for_all_fields_test() {
+//   let database_test = create_database_with_default_data(1, "1");
+//   database_test.create_field(Field::new(
+//     "f4".to_string(),
+//     "text field".to_string(),
+//     0,
+//     true,
+//   ));
 
-  let field_settings: HashMap<String, TestFieldSetting> =
-    database_test.get_field_settings("v1", None);
-  assert_eq!(field_settings.len(), 2);
-}
+//   let field_settings: HashMap<String, TestFieldSetting> =
+//     database_test.get_field_settings("v1", None);
+//   assert_eq!(field_settings.len(), 2);
+// }
 
-#[tokio::test]
-async fn new_view_new_field_setting_map_test() {
-  let database_test = create_database_with_default_data(1, "1");
-  database_test.create_field(Field::new(
-    "f4".to_string(),
-    "text field".to_string(),
-    0,
-    true,
-  ));
+// #[tokio::test]
+// async fn new_view_new_field_setting_map_test() {
+//   let database_test = create_database_with_default_data(1, "1");
+//   database_test.create_field(Field::new(
+//     "f4".to_string(),
+//     "text field".to_string(),
+//     0,
+//     true,
+//   ));
 
-  let field_settings: HashMap<String, TestFieldSetting> =
-    database_test.get_field_settings("v1", None);
-  assert_eq!(field_settings.len(), 2);
-}
+//   let field_settings: HashMap<String, TestFieldSetting> =
+//     database_test.get_field_settings("v1", None);
+//   assert_eq!(field_settings.len(), 2);
+// }
 
-#[tokio::test]
-async fn new_view_new_field_setting_map_test() {
-  let database_test = create_database_with_default_data(1, "1");
-  database_test.create_field(Field::new(
-    "f4".to_string(),
-    "text field".to_string(),
-    0,
-    true,
-  ));
+// #[tokio::test]
+// async fn new_view_new_field_setting_map_test() {
+//   let database_test = create_database_with_default_data(1, "1");
+//   database_test.create_field(Field::new(
+//     "f4".to_string(),
+//     "text field".to_string(),
+//     0,
+//     true,
+//   ));
 
-  let field_settings: HashMap<String, TestFieldSetting> =
-    database_test.get_field_settings("v1", None);
-  assert_eq!(field_settings.len(), 2);
-}
+//   let field_settings: HashMap<String, TestFieldSetting> =
+//     database_test.get_field_settings("v1", None);
+//   assert_eq!(field_settings.len(), 2);
+// }
 
-// duplicate a view, the field settings should be copied over
+// // duplicate a view, the field settings should be copied over
 
-// create a new view with a non-default field settings
+// // create a new view with a non-default field settings

--- a/collab-database/tests/database_test/field_test.rs
+++ b/collab-database/tests/database_test/field_test.rs
@@ -1,17 +1,17 @@
 use collab_database::fields::Field;
 use collab_database::views::CreateViewParams;
 
-use crate::database_test::helper::{create_database, create_database_with_default_data};
+use crate::database_test::helper::{
+  create_database, create_database_with_default_data, TestFieldSetting,
+};
 
 #[tokio::test]
 async fn create_single_field_test() {
   let database_test = create_database(1, "1");
-  database_test.create_field(Field::new(
-    "f1".to_string(),
-    "text field".to_string(),
-    0,
-    true,
-  ));
+  database_test.create_field(
+    Field::new("f1".to_string(), "text field".to_string(), 0, true),
+    TestFieldSetting::new().into(),
+  );
 
   let fields = database_test.fields.get_all_fields();
   assert_eq!(fields.len(), 1);
@@ -56,12 +56,10 @@ async fn duplicate_field_test2() {
 async fn create_multiple_field_test() {
   let database_test = create_database(1, "1");
   for i in 0..10 {
-    database_test.create_field(Field::new(
-      format!("f{}", i),
-      format!("text field {}", i),
-      0,
-      true,
-    ));
+    database_test.create_field(
+      Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
+      TestFieldSetting::new().into(),
+    );
   }
 
   let fields = database_test.fields.get_all_fields();
@@ -72,12 +70,10 @@ async fn create_multiple_field_test() {
 async fn delete_field_test() {
   let database_test = create_database(1, "1");
   for i in 0..3 {
-    database_test.create_field(Field::new(
-      format!("f{}", i),
-      format!("text field {}", i),
-      0,
-      true,
-    ));
+    database_test.create_field(
+      Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
+      TestFieldSetting::new().into(),
+    );
   }
   database_test.delete_field("f0");
   database_test.delete_field("f1");
@@ -89,12 +85,10 @@ async fn delete_field_test() {
 async fn delete_field_in_views_test() {
   let database_test = create_database(1, "1");
   for i in 0..3 {
-    database_test.create_field(Field::new(
-      format!("f{}", i),
-      format!("text field {}", i),
-      0,
-      true,
-    ));
+    database_test.create_field(
+      Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
+      TestFieldSetting::new().into(),
+    );
   }
 
   let params = CreateViewParams {
@@ -121,12 +115,10 @@ async fn field_order_in_view_test() {
   };
   database_test.create_linked_view(params).unwrap();
   for i in 0..10 {
-    database_test.create_field(Field::new(
-      format!("f{}", i),
-      format!("text field {}", i),
-      0,
-      true,
-    ));
+    database_test.create_field(
+      Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
+      TestFieldSetting::new().into(),
+    );
   }
 
   let fields = database_test.fields.get_all_fields();
@@ -142,12 +134,10 @@ async fn field_order_in_view_test() {
 async fn get_field_in_order_test() {
   let database_test = create_database(1, "1");
   for i in 0..3 {
-    database_test.create_field(Field::new(
-      format!("f{}", i),
-      format!("text field {}", i),
-      0,
-      true,
-    ));
+    database_test.create_field(
+      Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
+      TestFieldSetting::new().into(),
+    );
   }
   let fields = database_test.get_fields_in_view("v1", None);
   assert_eq!(fields[0].id, "f0");
@@ -174,12 +164,10 @@ async fn move_field_test() {
   database_test.create_linked_view(params).unwrap();
 
   for i in 0..3 {
-    database_test.create_field(Field::new(
-      format!("f{}", i),
-      format!("text field {}", i),
-      0,
-      true,
-    ));
+    database_test.create_field(
+      Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
+      TestFieldSetting::new().into(),
+    );
   }
 
   database_test.views.update_database_view("v1", |update| {
@@ -201,12 +189,10 @@ async fn move_field_test() {
 async fn move_field_to_out_of_index_test() {
   let database_test = create_database(1, "1");
   for i in 0..3 {
-    database_test.create_field(Field::new(
-      format!("f{}", i),
-      format!("text field {}", i),
-      0,
-      true,
-    ));
+    database_test.create_field(
+      Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
+      TestFieldSetting::new().into(),
+    );
   }
 
   database_test.views.update_database_view("v1", |update| {

--- a/collab-database/tests/database_test/field_test.rs
+++ b/collab-database/tests/database_test/field_test.rs
@@ -2,7 +2,7 @@ use collab_database::fields::Field;
 use collab_database::views::CreateViewParams;
 
 use crate::database_test::helper::{
-  create_database, create_database_with_default_data, TestFieldSetting,
+  create_database, create_database_with_default_data, default_field_settings_by_layout,
 };
 
 #[tokio::test]
@@ -10,7 +10,7 @@ async fn create_single_field_test() {
   let database_test = create_database(1, "1");
   database_test.create_field(
     Field::new("f1".to_string(), "text field".to_string(), 0, true),
-    TestFieldSetting::new().into(),
+    default_field_settings_by_layout(),
   );
 
   let fields = database_test.fields.get_all_fields();
@@ -58,7 +58,7 @@ async fn create_multiple_field_test() {
   for i in 0..10 {
     database_test.create_field(
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
-      TestFieldSetting::new().into(),
+      default_field_settings_by_layout(),
     );
   }
 
@@ -72,7 +72,7 @@ async fn delete_field_test() {
   for i in 0..3 {
     database_test.create_field(
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
-      TestFieldSetting::new().into(),
+      default_field_settings_by_layout(),
     );
   }
   database_test.delete_field("f0");
@@ -87,7 +87,7 @@ async fn delete_field_in_views_test() {
   for i in 0..3 {
     database_test.create_field(
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
-      TestFieldSetting::new().into(),
+      default_field_settings_by_layout(),
     );
   }
 
@@ -117,7 +117,7 @@ async fn field_order_in_view_test() {
   for i in 0..10 {
     database_test.create_field(
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
-      TestFieldSetting::new().into(),
+      default_field_settings_by_layout(),
     );
   }
 
@@ -136,7 +136,7 @@ async fn get_field_in_order_test() {
   for i in 0..3 {
     database_test.create_field(
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
-      TestFieldSetting::new().into(),
+      default_field_settings_by_layout(),
     );
   }
   let fields = database_test.get_fields_in_view("v1", None);
@@ -166,7 +166,7 @@ async fn move_field_test() {
   for i in 0..3 {
     database_test.create_field(
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
-      TestFieldSetting::new().into(),
+      default_field_settings_by_layout(),
     );
   }
 
@@ -191,7 +191,7 @@ async fn move_field_to_out_of_index_test() {
   for i in 0..3 {
     database_test.create_field(
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
-      TestFieldSetting::new().into(),
+      default_field_settings_by_layout(),
     );
   }
 

--- a/collab-database/tests/database_test/helper.rs
+++ b/collab-database/tests/database_test/helper.rs
@@ -284,7 +284,7 @@ pub fn field_settings_for_default_database() -> FieldSettingsMap {
   FieldSettingsMapBuilder::new()
     .insert_any("f1", field_settings.clone())
     .insert_any("f2", field_settings.clone())
-    .insert_any("f3", field_settings.clone())
+    .insert_any("f3", field_settings)
     .build()
 }
 

--- a/collab-database/tests/database_test/helper.rs
+++ b/collab-database/tests/database_test/helper.rs
@@ -265,18 +265,24 @@ pub fn create_database_with_default_data(uid: i64, database_id: &str) -> Databas
   let field_2 = Field::new("f2".to_string(), "single select field".to_string(), 2, true);
   let field_3 = Field::new("f3".to_string(), "checkbox field".to_string(), 1, true);
 
-  let field_setting = FieldSettings::from(TestFieldSetting { is_visible: true });
   database_test.create_field(field_1, TestFieldSetting::new().into());
   database_test.create_field(field_2, TestFieldSetting::new().into());
   database_test.create_field(field_3, TestFieldSetting::new().into());
 
-  database_test.insert_field_settings_for_fields(
-    "v1",
-    vec!["f1".to_string(), "f2".to_string(), "f3".to_string()],
-    field_setting,
-  );
+  database_test.set_field_settings("v1", field_settings_for_default_database());
 
   database_test
+}
+
+/// Creates the default field settings for the database created by
+/// create_database_with_default_data
+pub fn field_settings_for_default_database() -> FieldSettingsMap {
+  let field_settings = FieldSettings::from(TestFieldSetting { is_visible: true });
+  FieldSettingsMapBuilder::new()
+    .insert_any("f1", field_settings.clone())
+    .insert_any("f2", field_settings.clone())
+    .insert_any("f3", field_settings.clone())
+    .build()
 }
 
 struct Cleaner(PathBuf);

--- a/collab-database/tests/database_test/helper.rs
+++ b/collab-database/tests/database_test/helper.rs
@@ -10,7 +10,7 @@ use collab_database::fields::Field;
 use collab_database::rows::{CellsBuilder, CreateRowParams};
 use collab_database::user::DatabaseCollabService;
 use collab_database::views::{
-  CreateDatabaseParams, DatabaseLayout, FieldSetting, FieldSettingsMap, FieldSettingsMapBuilder,
+  CreateDatabaseParams, DatabaseLayout, FieldSettings, FieldSettingsMap, FieldSettingsMapBuilder,
   LayoutSetting, LayoutSettings,
 };
 use collab_persistence::kv::rocks_kv::RocksCollabDB;
@@ -265,7 +265,7 @@ pub fn create_database_with_default_data(uid: i64, database_id: &str) -> Databas
   let field_2 = Field::new("f2".to_string(), "single select field".to_string(), 2, true);
   let field_3 = Field::new("f3".to_string(), "checkbox field".to_string(), 1, true);
 
-  let field_setting = FieldSetting::from(TestFieldSetting { is_visible: true });
+  let field_setting = FieldSettings::from(TestFieldSetting { is_visible: true });
   database_test.create_field(field_1, TestFieldSetting::new().into());
   database_test.create_field(field_2, TestFieldSetting::new().into());
   database_test.create_field(field_3, TestFieldSetting::new().into());

--- a/collab-database/tests/database_test/helper.rs
+++ b/collab-database/tests/database_test/helper.rs
@@ -11,8 +11,8 @@ use collab_database::fields::Field;
 use collab_database::rows::{CellsBuilder, CreateRowParams};
 use collab_database::user::DatabaseCollabService;
 use collab_database::views::{
-  CreateDatabaseParams, DatabaseLayout, FieldSettingsMap, FieldSettingsMapBuilder, LayoutSetting,
-  LayoutSettings,
+  CreateDatabaseParams, DatabaseLayout, FieldSettingsByFieldIdMap,
+  FieldSettingsByFieldIdMapBuilder, FieldSettingsMap, LayoutSetting, LayoutSettings,
 };
 use collab_persistence::kv::rocks_kv::RocksCollabDB;
 use collab_plugins::cloud_storage::CollabType;
@@ -279,9 +279,9 @@ pub fn create_database_with_default_data(uid: i64, database_id: &str) -> Databas
 
 /// Creates the default field settings for the database created by
 /// create_database_with_default_data
-pub fn field_settings_for_default_database() -> FieldSettingsMap {
+pub fn field_settings_for_default_database() -> FieldSettingsByFieldIdMap {
   let field_settings = FieldSettingsMap::from(TestFieldSetting { is_visible: true });
-  FieldSettingsMapBuilder::new()
+  FieldSettingsByFieldIdMapBuilder::new()
     .insert_any("f1", field_settings.clone())
     .insert_any("f2", field_settings.clone())
     .insert_any("f3", field_settings)

--- a/collab-database/tests/database_test/helper.rs
+++ b/collab-database/tests/database_test/helper.rs
@@ -11,8 +11,8 @@ use collab_database::fields::Field;
 use collab_database::rows::{CellsBuilder, CreateRowParams};
 use collab_database::user::DatabaseCollabService;
 use collab_database::views::{
-  CreateDatabaseParams, DatabaseLayout, FieldSettings, FieldSettingsMap, FieldSettingsMapBuilder,
-  LayoutSetting, LayoutSettings,
+  CreateDatabaseParams, DatabaseLayout, FieldSettingsMap, FieldSettingsMapBuilder, LayoutSetting,
+  LayoutSettings,
 };
 use collab_persistence::kv::rocks_kv::RocksCollabDB;
 use collab_plugins::cloud_storage::CollabType;
@@ -280,7 +280,7 @@ pub fn create_database_with_default_data(uid: i64, database_id: &str) -> Databas
 /// Creates the default field settings for the database created by
 /// create_database_with_default_data
 pub fn field_settings_for_default_database() -> FieldSettingsMap {
-  let field_settings = FieldSettings::from(TestFieldSetting { is_visible: true });
+  let field_settings = FieldSettingsMap::from(TestFieldSetting { is_visible: true });
   FieldSettingsMapBuilder::new()
     .insert_any("f1", field_settings.clone())
     .insert_any("f2", field_settings.clone())
@@ -288,7 +288,7 @@ pub fn field_settings_for_default_database() -> FieldSettingsMap {
     .build()
 }
 
-pub fn default_field_settings_by_layout() -> HashMap<DatabaseLayout, FieldSettings> {
+pub fn default_field_settings_by_layout() -> HashMap<DatabaseLayout, FieldSettingsMap> {
   let field_settings = TestFieldSetting { is_visible: true };
   HashMap::from([
     (DatabaseLayout::Grid, field_settings.clone().into()),

--- a/collab-database/tests/database_test/helper.rs
+++ b/collab-database/tests/database_test/helper.rs
@@ -9,7 +9,10 @@ use collab_database::database::{Database, DatabaseContext};
 use collab_database::fields::Field;
 use collab_database::rows::{CellsBuilder, CreateRowParams};
 use collab_database::user::DatabaseCollabService;
-use collab_database::views::{CreateDatabaseParams, DatabaseLayout, LayoutSetting, LayoutSettings};
+use collab_database::views::{
+  CreateDatabaseParams, DatabaseLayout, FieldSetting, FieldSettingsMap, FieldSettingsMapBuilder,
+  LayoutSetting, LayoutSettings,
+};
 use collab_persistence::kv::rocks_kv::RocksCollabDB;
 use collab_plugins::cloud_storage::CollabType;
 use collab_plugins::local_storage::CollabPersistenceConfig;
@@ -141,6 +144,7 @@ pub struct DatabaseTestBuilder {
   layout_settings: LayoutSettings,
   fields: Vec<Field>,
   layout: DatabaseLayout,
+  field_settings: FieldSettingsMap,
 }
 
 impl DatabaseTestBuilder {
@@ -153,6 +157,7 @@ impl DatabaseTestBuilder {
       layout_settings: Default::default(),
       fields: vec![],
       layout: DatabaseLayout::Grid,
+      field_settings: Default::default(),
     }
   }
 
@@ -201,6 +206,7 @@ impl DatabaseTestBuilder {
       filters: vec![],
       groups: vec![],
       sorts: vec![],
+      field_settings: self.field_settings,
       created_rows: self.rows,
       fields: self.fields,
     };
@@ -259,9 +265,16 @@ pub fn create_database_with_default_data(uid: i64, database_id: &str) -> Databas
   let field_2 = Field::new("f2".to_string(), "single select field".to_string(), 2, true);
   let field_3 = Field::new("f3".to_string(), "checkbox field".to_string(), 1, true);
 
+  let field_setting = FieldSetting::from(TestFieldSetting { is_visible: true });
   database_test.create_field(field_1);
   database_test.create_field(field_2);
   database_test.create_field(field_3);
+
+  database_test.insert_field_settings_for_fields(
+    "v1",
+    vec!["f1".to_string(), "f2".to_string(), "f3".to_string()],
+    field_setting,
+  );
 
   database_test
 }

--- a/collab-database/tests/database_test/helper.rs
+++ b/collab-database/tests/database_test/helper.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -265,9 +266,11 @@ pub fn create_database_with_default_data(uid: i64, database_id: &str) -> Databas
   let field_2 = Field::new("f2".to_string(), "single select field".to_string(), 2, true);
   let field_3 = Field::new("f3".to_string(), "checkbox field".to_string(), 1, true);
 
-  database_test.create_field(field_1, TestFieldSetting::new().into());
-  database_test.create_field(field_2, TestFieldSetting::new().into());
-  database_test.create_field(field_3, TestFieldSetting::new().into());
+  let field_settings_by_layout = default_field_settings_by_layout();
+
+  database_test.create_field(field_1, field_settings_by_layout.clone());
+  database_test.create_field(field_2, field_settings_by_layout.clone());
+  database_test.create_field(field_3, field_settings_by_layout);
 
   database_test.set_field_settings("v1", field_settings_for_default_database());
 
@@ -283,6 +286,18 @@ pub fn field_settings_for_default_database() -> FieldSettingsMap {
     .insert_any("f2", field_settings.clone())
     .insert_any("f3", field_settings.clone())
     .build()
+}
+
+pub fn default_field_settings_by_layout() -> HashMap<DatabaseLayout, FieldSettings> {
+  let field_settings = TestFieldSetting { is_visible: true };
+  HashMap::from([
+    (DatabaseLayout::Grid, field_settings.clone().into()),
+    (DatabaseLayout::Board, field_settings.into()),
+    (
+      DatabaseLayout::Calendar,
+      TestFieldSetting { is_visible: false }.into(),
+    ),
+  ])
 }
 
 struct Cleaner(PathBuf);

--- a/collab-database/tests/database_test/helper.rs
+++ b/collab-database/tests/database_test/helper.rs
@@ -266,9 +266,9 @@ pub fn create_database_with_default_data(uid: i64, database_id: &str) -> Databas
   let field_3 = Field::new("f3".to_string(), "checkbox field".to_string(), 1, true);
 
   let field_setting = FieldSetting::from(TestFieldSetting { is_visible: true });
-  database_test.create_field(field_1);
-  database_test.create_field(field_2);
-  database_test.create_field(field_3);
+  database_test.create_field(field_1, TestFieldSetting::new().into());
+  database_test.create_field(field_2, TestFieldSetting::new().into());
+  database_test.create_field(field_3, TestFieldSetting::new().into());
 
   database_test.insert_field_settings_for_fields(
     "v1",

--- a/collab-database/tests/database_test/mod.rs
+++ b/collab-database/tests/database_test/mod.rs
@@ -1,5 +1,6 @@
 mod block_test;
 mod cell_test;
+mod field_setting_test;
 mod field_test;
 mod filter_test;
 mod group_test;

--- a/collab-database/tests/database_test/restore_test.rs
+++ b/collab-database/tests/database_test/restore_test.rs
@@ -401,7 +401,8 @@ async fn open_020_history_database_test() {
           "id": "s:4SJjUs",
           "ty": 0
         }
-      ]
+      ],
+      "field_settings": {}
     }
   });
   let expected_data: DatabaseData = serde_json::from_value(json_value).unwrap();

--- a/collab-database/tests/database_test/type_option_test.rs
+++ b/collab-database/tests/database_test/type_option_test.rs
@@ -1,7 +1,7 @@
 use collab::core::any_map::AnyMapExtension;
 use collab_database::fields::{Field, TypeOptionDataBuilder, TypeOptions};
 
-use crate::database_test::helper::{create_database, DatabaseTest};
+use crate::database_test::helper::{create_database, DatabaseTest, TestFieldSetting};
 use crate::helper::{TestCheckboxTypeOption, TestDateFormat, TestDateTypeOption, TestTimeFormat};
 
 #[tokio::test]
@@ -122,13 +122,16 @@ async fn insert_multi_type_options_test() {
       .build(),
   );
 
-  test.create_field(Field {
-    id: "f2".to_string(),
-    name: "second field".to_string(),
-    field_type: 0,
-    type_options,
-    ..Default::default()
-  });
+  test.create_field(
+    Field {
+      id: "f2".to_string(),
+      name: "second field".to_string(),
+      field_type: 0,
+      type_options,
+      ..Default::default()
+    },
+    TestFieldSetting::new().into(),
+  );
 
   let second_field = test.fields.get_field("f2").unwrap();
   assert_eq!(second_field.type_options.len(), 2);

--- a/collab-database/tests/database_test/type_option_test.rs
+++ b/collab-database/tests/database_test/type_option_test.rs
@@ -1,7 +1,9 @@
 use collab::core::any_map::AnyMapExtension;
 use collab_database::fields::{Field, TypeOptionDataBuilder, TypeOptions};
 
-use crate::database_test::helper::{create_database, DatabaseTest, TestFieldSetting};
+use crate::database_test::helper::{
+  create_database, default_field_settings_by_layout, DatabaseTest,
+};
 use crate::helper::{TestCheckboxTypeOption, TestDateFormat, TestDateTypeOption, TestTimeFormat};
 
 #[tokio::test]
@@ -130,7 +132,7 @@ async fn insert_multi_type_options_test() {
       type_options,
       ..Default::default()
     },
-    TestFieldSetting::new().into(),
+    default_field_settings_by_layout(),
   );
 
   let second_field = test.fields.get_field("f2").unwrap();

--- a/collab-database/tests/database_test/view_test.rs
+++ b/collab-database/tests/database_test/view_test.rs
@@ -9,7 +9,7 @@ use serde_json::json;
 use assert_json_diff::{assert_json_eq, assert_json_include};
 
 use crate::database_test::helper::{
-  create_database, create_database_with_default_data, TestFieldSetting,
+  create_database, create_database_with_default_data, default_field_settings_by_layout,
 };
 use crate::helper::TestFilter;
 
@@ -99,7 +99,7 @@ async fn create_database_field_test() {
       name: "my third field".to_string(),
       ..Default::default()
     },
-    TestFieldSetting::new().into(),
+    default_field_settings_by_layout(),
   );
 
   let view = database_test.views.get_view("v1").unwrap();

--- a/collab-database/tests/database_test/view_test.rs
+++ b/collab-database/tests/database_test/view_test.rs
@@ -8,7 +8,9 @@ use serde_json::json;
 
 use assert_json_diff::{assert_json_eq, assert_json_include};
 
-use crate::database_test::helper::{create_database, create_database_with_default_data};
+use crate::database_test::helper::{
+  create_database, create_database_with_default_data, TestFieldSetting,
+};
 use crate::helper::TestFilter;
 
 #[tokio::test]
@@ -91,11 +93,14 @@ async fn create_database_field_test() {
   let database_test = create_database_with_default_data(1, "1");
 
   let field_id = nanoid!(4);
-  database_test.create_field(Field {
-    id: field_id.clone(),
-    name: "my third field".to_string(),
-    ..Default::default()
-  });
+  database_test.create_field(
+    Field {
+      id: field_id.clone(),
+      name: "my third field".to_string(),
+      ..Default::default()
+    },
+    TestFieldSetting::new().into(),
+  );
 
   let view = database_test.views.get_view("v1").unwrap();
   assert_json_eq!(view.field_orders.last().unwrap().id, field_id);

--- a/collab-database/tests/database_test/view_test.rs
+++ b/collab-database/tests/database_test/view_test.rs
@@ -154,12 +154,13 @@ async fn create_database_view_with_layout_setting_test() {
     .insert_any("2", "abc")
     .build();
 
-  let params = CreateViewParams::new(
-    "1".to_string(),
-    "v1".to_string(),
-    "my first grid".to_string(),
-    DatabaseLayout::Grid,
-  )
+  let params = CreateViewParams {
+    database_id: "1".to_string(),
+    view_id: "v1".to_string(),
+    name: "my first grid".to_string(),
+    layout: DatabaseLayout::Grid,
+    ..Default::default()
+  }
   .with_layout_setting(grid_setting);
   database_test.create_linked_view(params).unwrap();
 

--- a/collab-database/tests/helper/util.rs
+++ b/collab-database/tests/helper/util.rs
@@ -11,7 +11,7 @@ use collab::preclude::lib0Any;
 use collab_database::fields::{TypeOptionData, TypeOptionDataBuilder};
 use collab_database::rows::Cell;
 use collab_database::views::{
-  FieldSetting, FilterMap, FilterMapBuilder, GroupMap, GroupMapBuilder, GroupSettingBuilder,
+  FieldSettings, FilterMap, FilterMapBuilder, GroupMap, GroupMapBuilder, GroupSettingBuilder,
   GroupSettingMap, LayoutSetting, LayoutSettingBuilder, SortMap, SortMapBuilder,
 };
 use collab_persistence::kv::rocks_kv::RocksCollabDB;
@@ -542,15 +542,15 @@ impl TestFieldSetting {
 
 const VISIBILITY: &str = "visibility";
 
-impl From<FieldSetting> for TestFieldSetting {
-  fn from(value: FieldSetting) -> Self {
+impl From<FieldSettings> for TestFieldSetting {
+  fn from(value: FieldSettings) -> Self {
     TestFieldSetting {
       is_visible: value.get_bool_value(VISIBILITY).unwrap_or(true),
     }
   }
 }
 
-impl From<TestFieldSetting> for FieldSetting {
+impl From<TestFieldSetting> for FieldSettings {
   fn from(data: TestFieldSetting) -> Self {
     SortMapBuilder::new()
       .insert_bool_value(VISIBILITY, data.is_visible)

--- a/collab-database/tests/helper/util.rs
+++ b/collab-database/tests/helper/util.rs
@@ -534,6 +534,12 @@ pub struct TestFieldSetting {
   pub is_visible: bool,
 }
 
+impl TestFieldSetting {
+  pub fn new() -> Self {
+    Self { is_visible: true }
+  }
+}
+
 const VISIBILITY: &str = "visibility";
 
 impl From<FieldSetting> for TestFieldSetting {

--- a/collab-database/tests/helper/util.rs
+++ b/collab-database/tests/helper/util.rs
@@ -11,8 +11,9 @@ use collab::preclude::lib0Any;
 use collab_database::fields::{TypeOptionData, TypeOptionDataBuilder};
 use collab_database::rows::Cell;
 use collab_database::views::{
-  FieldSettings, FilterMap, FilterMapBuilder, GroupMap, GroupMapBuilder, GroupSettingBuilder,
-  GroupSettingMap, LayoutSetting, LayoutSettingBuilder, SortMap, SortMapBuilder,
+  FieldSettingsMap, FieldSettingsMapBuilder, FilterMap, FilterMapBuilder, GroupMap,
+  GroupMapBuilder, GroupSettingBuilder, GroupSettingMap, LayoutSetting, LayoutSettingBuilder,
+  SortMap, SortMapBuilder,
 };
 use collab_persistence::kv::rocks_kv::RocksCollabDB;
 use nanoid::nanoid;
@@ -548,17 +549,17 @@ impl TestFieldSetting {
 
 const VISIBILITY: &str = "visibility";
 
-impl From<FieldSettings> for TestFieldSetting {
-  fn from(value: FieldSettings) -> Self {
+impl From<FieldSettingsMap> for TestFieldSetting {
+  fn from(value: FieldSettingsMap) -> Self {
     TestFieldSetting {
       is_visible: value.get_bool_value(VISIBILITY).unwrap_or(true),
     }
   }
 }
 
-impl From<TestFieldSetting> for FieldSettings {
+impl From<TestFieldSetting> for FieldSettingsMap {
   fn from(data: TestFieldSetting) -> Self {
-    SortMapBuilder::new()
+    FieldSettingsMapBuilder::new()
       .insert_bool_value(VISIBILITY, data.is_visible)
       .build()
   }

--- a/collab-database/tests/helper/util.rs
+++ b/collab-database/tests/helper/util.rs
@@ -11,8 +11,8 @@ use collab::preclude::lib0Any;
 use collab_database::fields::{TypeOptionData, TypeOptionDataBuilder};
 use collab_database::rows::Cell;
 use collab_database::views::{
-  FilterMap, FilterMapBuilder, GroupMap, GroupMapBuilder, GroupSettingBuilder, GroupSettingMap,
-  LayoutSetting, LayoutSettingBuilder, SortMap, SortMapBuilder,
+  FieldSetting, FilterMap, FilterMapBuilder, GroupMap, GroupMapBuilder, GroupSettingBuilder,
+  GroupSettingMap, LayoutSetting, LayoutSettingBuilder, SortMap, SortMapBuilder,
 };
 use collab_persistence::kv::rocks_kv::RocksCollabDB;
 use nanoid::nanoid;
@@ -526,6 +526,29 @@ impl std::convert::From<i64> for TestFieldType {
         TestFieldType::RichText
       },
     }
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct TestFieldSetting {
+  pub is_visible: bool,
+}
+
+const VISIBILITY: &str = "visibility";
+
+impl From<FieldSetting> for TestFieldSetting {
+  fn from(value: FieldSetting) -> Self {
+    TestFieldSetting {
+      is_visible: value.get_bool_value(VISIBILITY).unwrap_or(true),
+    }
+  }
+}
+
+impl From<TestFieldSetting> for FieldSetting {
+  fn from(data: TestFieldSetting) -> Self {
+    SortMapBuilder::new()
+      .insert_bool_value(VISIBILITY, data.is_visible)
+      .build()
   }
 }
 

--- a/collab-database/tests/helper/util.rs
+++ b/collab-database/tests/helper/util.rs
@@ -534,6 +534,12 @@ pub struct TestFieldSetting {
   pub is_visible: bool,
 }
 
+impl Default for TestFieldSetting {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
 impl TestFieldSetting {
   pub fn new() -> Self {
     Self { is_visible: true }

--- a/collab-database/tests/user_test/async_test/script.rs
+++ b/collab-database/tests/user_test/async_test/script.rs
@@ -8,7 +8,7 @@ use collab_database::fields::Field;
 use collab_database::rows::CreateRowParams;
 use collab_database::rows::{Cells, CellsBuilder, RowId};
 use collab_database::user::WorkspaceDatabase;
-use collab_database::views::{CreateDatabaseParams, FieldSettings, FieldSettingsMapBuilder};
+use collab_database::views::{CreateDatabaseParams, FieldSettingsMap, FieldSettingsMapBuilder};
 use collab_persistence::doc::YrsDocAction;
 use collab_persistence::kv::rocks_kv::RocksCollabDB;
 use collab_plugins::local_storage::CollabPersistenceConfig;
@@ -226,7 +226,7 @@ pub fn create_database(database_id: &str) -> CreateDatabaseParams {
   let field_2 = Field::new("f2".to_string(), "single select field".to_string(), 2, true);
   let field_3 = Field::new("f3".to_string(), "checkbox field".to_string(), 1, true);
 
-  let field_setting = FieldSettings::from(TestFieldSetting { is_visible: true });
+  let field_setting = FieldSettingsMap::from(TestFieldSetting { is_visible: true });
   let field_settings_map = FieldSettingsMapBuilder::new()
     .insert_any("f1", field_setting.clone())
     .insert_any("f2", field_setting.clone())

--- a/collab-database/tests/user_test/async_test/script.rs
+++ b/collab-database/tests/user_test/async_test/script.rs
@@ -8,7 +8,7 @@ use collab_database::fields::Field;
 use collab_database::rows::CreateRowParams;
 use collab_database::rows::{Cells, CellsBuilder, RowId};
 use collab_database::user::WorkspaceDatabase;
-use collab_database::views::{CreateDatabaseParams, FieldSetting, FieldSettingsMapBuilder};
+use collab_database::views::{CreateDatabaseParams, FieldSettings, FieldSettingsMapBuilder};
 use collab_persistence::doc::YrsDocAction;
 use collab_persistence::kv::rocks_kv::RocksCollabDB;
 use collab_plugins::local_storage::CollabPersistenceConfig;
@@ -226,7 +226,7 @@ pub fn create_database(database_id: &str) -> CreateDatabaseParams {
   let field_2 = Field::new("f2".to_string(), "single select field".to_string(), 2, true);
   let field_3 = Field::new("f3".to_string(), "checkbox field".to_string(), 1, true);
 
-  let field_setting = FieldSetting::from(TestFieldSetting { is_visible: true });
+  let field_setting = FieldSettings::from(TestFieldSetting { is_visible: true });
   let field_settings_map = FieldSettingsMapBuilder::new()
     .insert_any("f1", field_setting.clone())
     .insert_any("f2", field_setting.clone())

--- a/collab-database/tests/user_test/async_test/script.rs
+++ b/collab-database/tests/user_test/async_test/script.rs
@@ -8,12 +8,13 @@ use collab_database::fields::Field;
 use collab_database::rows::CreateRowParams;
 use collab_database::rows::{Cells, CellsBuilder, RowId};
 use collab_database::user::WorkspaceDatabase;
-use collab_database::views::CreateDatabaseParams;
+use collab_database::views::{CreateDatabaseParams, FieldSetting, FieldSettingsMapBuilder};
 use collab_persistence::doc::YrsDocAction;
 use collab_persistence::kv::rocks_kv::RocksCollabDB;
 use collab_plugins::local_storage::CollabPersistenceConfig;
 use serde_json::Value;
 
+use crate::database_test::helper::TestFieldSetting;
 use crate::helper::{db_path, TestTextCell};
 use crate::user_test::helper::workspace_database_with_db;
 
@@ -225,6 +226,13 @@ pub fn create_database(database_id: &str) -> CreateDatabaseParams {
   let field_2 = Field::new("f2".to_string(), "single select field".to_string(), 2, true);
   let field_3 = Field::new("f3".to_string(), "checkbox field".to_string(), 1, true);
 
+  let field_setting = FieldSetting::from(TestFieldSetting { is_visible: true });
+  let field_settings_map = FieldSettingsMapBuilder::new()
+    .insert_any("f1", field_setting.clone())
+    .insert_any("f2", field_setting.clone())
+    .insert_any("f3", field_setting.clone())
+    .build();
+
   CreateDatabaseParams {
     database_id: database_id.to_string(),
     view_id: "v1".to_string(),
@@ -234,6 +242,7 @@ pub fn create_database(database_id: &str) -> CreateDatabaseParams {
     filters: vec![],
     groups: vec![],
     sorts: vec![],
+    field_settings: field_settings_map,
     created_rows: vec![row_1, row_2, row_3],
     fields: vec![field_1, field_2, field_3],
   }

--- a/collab-database/tests/user_test/helper.rs
+++ b/collab-database/tests/user_test/helper.rs
@@ -15,7 +15,7 @@ use collab_database::user::{
   RowRelationChange, RowRelationUpdateReceiver, WorkspaceDatabase,
 };
 use collab_database::views::{
-  CreateDatabaseParams, DatabaseLayout, FieldSettings, FieldSettingsMapBuilder,
+  CreateDatabaseParams, DatabaseLayout, FieldSettingsMap, FieldSettingsMapBuilder,
 };
 use collab_persistence::kv::rocks_kv::RocksCollabDB;
 use collab_plugins::cloud_storage::CollabType;
@@ -206,7 +206,7 @@ fn create_database_params(database_id: &str) -> CreateDatabaseParams {
   let field_2 = Field::new("f2".to_string(), "single select field".to_string(), 2, true);
   let field_3 = Field::new("f3".to_string(), "checkbox field".to_string(), 1, true);
 
-  let field_setting = FieldSettings::from(TestFieldSetting { is_visible: true });
+  let field_setting = FieldSettingsMap::from(TestFieldSetting { is_visible: true });
   let field_settings_map = FieldSettingsMapBuilder::new()
     .insert_any("f1", field_setting.clone())
     .insert_any("f2", field_setting.clone())
@@ -276,7 +276,7 @@ pub fn make_default_grid(view_id: &str, name: &str) -> CreateDatabaseParams {
     is_primary: false,
   };
 
-  let field_setting = FieldSettings::from(TestFieldSetting { is_visible: true });
+  let field_setting = FieldSettingsMap::from(TestFieldSetting { is_visible: true });
   let field_settings_map = FieldSettingsMapBuilder::new()
     .insert_any(text_field.id.clone(), field_setting.clone())
     .insert_any(single_select_field.id.clone(), field_setting.clone())

--- a/collab-database/tests/user_test/helper.rs
+++ b/collab-database/tests/user_test/helper.rs
@@ -14,7 +14,9 @@ use collab_database::user::{
   CollabFuture, CollabObjectUpdate, CollabObjectUpdateByOid, DatabaseCollabService,
   RowRelationChange, RowRelationUpdateReceiver, WorkspaceDatabase,
 };
-use collab_database::views::{CreateDatabaseParams, DatabaseLayout};
+use collab_database::views::{
+  CreateDatabaseParams, DatabaseLayout, FieldSetting, FieldSettingsMapBuilder,
+};
 use collab_persistence::kv::rocks_kv::RocksCollabDB;
 use collab_plugins::cloud_storage::CollabType;
 use collab_plugins::local_storage::rocksdb::RocksdbDiskPlugin;
@@ -25,6 +27,7 @@ use tokio::sync::mpsc::{channel, Receiver};
 use rand::Rng;
 use tempfile::TempDir;
 
+use crate::database_test::helper::TestFieldSetting;
 use crate::helper::{make_rocks_db, TestTextCell};
 
 pub struct WorkspaceDatabaseTest {
@@ -203,6 +206,13 @@ fn create_database_params(database_id: &str) -> CreateDatabaseParams {
   let field_2 = Field::new("f2".to_string(), "single select field".to_string(), 2, true);
   let field_3 = Field::new("f3".to_string(), "checkbox field".to_string(), 1, true);
 
+  let field_setting = FieldSetting::from(TestFieldSetting { is_visible: true });
+  let field_settings_map = FieldSettingsMapBuilder::new()
+    .insert_any("f1", field_setting.clone())
+    .insert_any("f2", field_setting.clone())
+    .insert_any("f3", field_setting.clone())
+    .build();
+
   CreateDatabaseParams {
     database_id: database_id.to_string(),
     view_id: "v1".to_string(),
@@ -212,6 +222,7 @@ fn create_database_params(database_id: &str) -> CreateDatabaseParams {
     filters: vec![],
     groups: vec![],
     sorts: vec![],
+    field_settings: field_settings_map,
     created_rows: vec![row_1, row_2, row_3],
     fields: vec![field_1, field_2, field_3],
   }
@@ -265,6 +276,13 @@ pub fn make_default_grid(view_id: &str, name: &str) -> CreateDatabaseParams {
     is_primary: false,
   };
 
+  let field_setting = FieldSetting::from(TestFieldSetting { is_visible: true });
+  let field_settings_map = FieldSettingsMapBuilder::new()
+    .insert_any(text_field.id.clone(), field_setting.clone())
+    .insert_any(single_select_field.id.clone(), field_setting.clone())
+    .insert_any(checkbox_field.id.clone(), field_setting.clone())
+    .build();
+
   CreateDatabaseParams {
     database_id: gen_database_id(),
     view_id: view_id.to_string(),
@@ -274,6 +292,7 @@ pub fn make_default_grid(view_id: &str, name: &str) -> CreateDatabaseParams {
     filters: vec![],
     groups: vec![],
     sorts: vec![],
+    field_settings: field_settings_map,
     created_rows: vec![
       CreateRowParams::new(gen_row_id()),
       CreateRowParams::new(gen_row_id()),

--- a/collab-database/tests/user_test/helper.rs
+++ b/collab-database/tests/user_test/helper.rs
@@ -15,7 +15,7 @@ use collab_database::user::{
   RowRelationChange, RowRelationUpdateReceiver, WorkspaceDatabase,
 };
 use collab_database::views::{
-  CreateDatabaseParams, DatabaseLayout, FieldSetting, FieldSettingsMapBuilder,
+  CreateDatabaseParams, DatabaseLayout, FieldSettings, FieldSettingsMapBuilder,
 };
 use collab_persistence::kv::rocks_kv::RocksCollabDB;
 use collab_plugins::cloud_storage::CollabType;
@@ -206,7 +206,7 @@ fn create_database_params(database_id: &str) -> CreateDatabaseParams {
   let field_2 = Field::new("f2".to_string(), "single select field".to_string(), 2, true);
   let field_3 = Field::new("f3".to_string(), "checkbox field".to_string(), 1, true);
 
-  let field_setting = FieldSetting::from(TestFieldSetting { is_visible: true });
+  let field_setting = FieldSettings::from(TestFieldSetting { is_visible: true });
   let field_settings_map = FieldSettingsMapBuilder::new()
     .insert_any("f1", field_setting.clone())
     .insert_any("f2", field_setting.clone())
@@ -276,7 +276,7 @@ pub fn make_default_grid(view_id: &str, name: &str) -> CreateDatabaseParams {
     is_primary: false,
   };
 
-  let field_setting = FieldSetting::from(TestFieldSetting { is_visible: true });
+  let field_setting = FieldSettings::from(TestFieldSetting { is_visible: true });
   let field_settings_map = FieldSettingsMapBuilder::new()
     .insert_any(text_field.id.clone(), field_setting.clone())
     .insert_any(single_select_field.id.clone(), field_setting.clone())

--- a/collab-database/tests/user_test/helper.rs
+++ b/collab-database/tests/user_test/helper.rs
@@ -210,7 +210,7 @@ fn create_database_params(database_id: &str) -> CreateDatabaseParams {
   let field_settings_map = FieldSettingsMapBuilder::new()
     .insert_any("f1", field_setting.clone())
     .insert_any("f2", field_setting.clone())
-    .insert_any("f3", field_setting.clone())
+    .insert_any("f3", field_setting)
     .build();
 
   CreateDatabaseParams {
@@ -280,7 +280,7 @@ pub fn make_default_grid(view_id: &str, name: &str) -> CreateDatabaseParams {
   let field_settings_map = FieldSettingsMapBuilder::new()
     .insert_any(text_field.id.clone(), field_setting.clone())
     .insert_any(single_select_field.id.clone(), field_setting.clone())
-    .insert_any(checkbox_field.id.clone(), field_setting.clone())
+    .insert_any(checkbox_field.id.clone(), field_setting)
     .build();
 
   CreateDatabaseParams {

--- a/collab-database/tests/user_test/type_option_test.rs
+++ b/collab-database/tests/user_test/type_option_test.rs
@@ -2,7 +2,7 @@ use collab::core::any_map::AnyMapExtension;
 use collab_database::fields::{Field, TypeOptionDataBuilder, TypeOptions};
 use collab_database::views::CreateDatabaseParams;
 
-use crate::database_test::helper::TestFieldSetting;
+use crate::database_test::helper::default_field_settings_by_layout;
 use crate::user_test::helper::{workspace_database_test, WorkspaceDatabaseTest};
 
 #[tokio::test]
@@ -52,7 +52,7 @@ async fn insert_multi_type_options_test() {
       type_options,
       ..Default::default()
     },
-    TestFieldSetting::new().into(),
+    default_field_settings_by_layout(),
   );
 
   let second_field = database.lock().fields.get_field("f2").unwrap();

--- a/collab-database/tests/user_test/type_option_test.rs
+++ b/collab-database/tests/user_test/type_option_test.rs
@@ -2,6 +2,7 @@ use collab::core::any_map::AnyMapExtension;
 use collab_database::fields::{Field, TypeOptionDataBuilder, TypeOptions};
 use collab_database::views::CreateDatabaseParams;
 
+use crate::database_test::helper::TestFieldSetting;
 use crate::user_test::helper::{workspace_database_test, WorkspaceDatabaseTest};
 
 #[tokio::test]
@@ -43,13 +44,16 @@ async fn insert_multi_type_options_test() {
       .build(),
   );
 
-  database.lock().create_field(Field {
-    id: "f2".to_string(),
-    name: "second field".to_string(),
-    field_type: 0,
-    type_options,
-    ..Default::default()
-  });
+  database.lock().create_field(
+    Field {
+      id: "f2".to_string(),
+      name: "second field".to_string(),
+      field_type: 0,
+      type_options,
+      ..Default::default()
+    },
+    TestFieldSetting::new().into(),
+  );
 
   let second_field = database.lock().fields.get_field("f2").unwrap();
   assert_eq!(second_field.type_options.len(), 2);

--- a/collab/src/core/any_map.rs
+++ b/collab/src/core/any_map.rs
@@ -431,11 +431,10 @@ impl<'a, 'b> AnyMapUpdate<'a, 'b> {
     self.map_ref.insert_with_txn(self.txn, key, value.into());
   }
 
-  pub fn update<K: AsRef<str>>(self, key: K, f: impl FnOnce(AnyMap) -> AnyMap) -> Self {
+  pub fn update<K: AsRef<str>>(self, key: K, value: AnyMap) -> Self {
     let key = key.as_ref();
     let field_setting_map = self.map_ref.get_or_insert_map_with_txn(self.txn, key);
-    let any_map = AnyMap::from_map_ref(self.txn, &field_setting_map);
-    f(any_map).fill_map_ref(self.txn, &field_setting_map);
+    value.fill_map_ref(self.txn, &field_setting_map);
 
     self
   }

--- a/collab/src/core/any_map.rs
+++ b/collab/src/core/any_map.rs
@@ -407,4 +407,19 @@ impl<'a, 'b> AnyMapUpdate<'a, 'b> {
     let key = key.as_ref();
     self.map_ref.insert_with_txn(self.txn, key, value.into());
   }
+
+  pub fn update<K: AsRef<str>>(self, key: K, f: impl FnOnce(AnyMap) -> AnyMap) -> Self {
+    let key = key.as_ref();
+    let field_setting_map = self.map_ref.get_or_insert_map_with_txn(self.txn, key);
+    let any_map = AnyMap::from_map_ref(self.txn, &field_setting_map);
+    f(any_map).fill_map_ref(self.txn, &field_setting_map);
+
+    self
+  }
+
+  pub fn remove<K: AsRef<str>>(self, key: K) -> Self {
+    let key = key.as_ref();
+    self.map_ref.remove(self.txn, key);
+    self
+  }
 }


### PR DESCRIPTION
Introduces `field_settings`, a map in a database view that describes each field's settings. The goal is to separate the field settings in a view from the field's more inherent settings. In json format, this looks something like the following:

```
{
   "field settings": {
      "field_1_id": {
         "is_visible": true,
         "width": 100
      },
      "field_2_id": {
         "is_visible": true,
         "width": 150
      },
      "field_3_id": {
         "is_visible": false,
         "width": 50
      }
   }
}
```