### PR TITLE
feat: pinpoint new object location in order array

### DIFF
--- a/collab-database/src/database.rs
+++ b/collab-database/src/database.rs
@@ -494,7 +494,7 @@ impl Database {
     &self,
     view_id: Option<&str>,
     field: Field,
-    position: OrderObjectPosition,
+    position: &OrderObjectPosition,
     field_settings_by_layout: HashMap<DatabaseLayout, FieldSettingsMap>,
   ) {
     self.root.with_transact_mut(|txn| {
@@ -520,7 +520,7 @@ impl Database {
     txn: &mut TransactionMut,
     view_id: Option<&str>,
     field: Field,
-    position: OrderObjectPosition,
+    position: &OrderObjectPosition,
     field_settings_by_layout: &HashMap<DatabaseLayout, FieldSettingsMap>,
   ) {
     self.views.update_all_views_with_txn(txn, |id, update| {
@@ -548,7 +548,7 @@ impl Database {
     view_id: &str,
     name: String,
     field_type: i64,
-    position: OrderObjectPosition,
+    position: &OrderObjectPosition,
     f: impl FnOnce(&mut Field),
     field_settings_by_layout: HashMap<DatabaseLayout, FieldSettingsMap>,
   ) -> (usize, Field) {
@@ -913,7 +913,7 @@ impl Database {
               txn,
               None,
               field,
-              OrderObjectPosition::default(),
+              &OrderObjectPosition::default(),
               &field_settings,
             );
           })

--- a/collab-database/src/database.rs
+++ b/collab-database/src/database.rs
@@ -525,9 +525,9 @@ impl Database {
   ) {
     self.views.update_all_views_with_txn(txn, |id, update| {
       let update = match view_id {
-        Some(view_id) if id == view_id => update.insert_field_order(&field, &position),
+        Some(view_id) if id == view_id => update.insert_field_order(&field, position),
         Some(_) => update.insert_field_order(&field, &OrderObjectPosition::default()),
-        None => update.insert_field_order(&field, &position),
+        None => update.insert_field_order(&field, position),
       };
 
       update.update_field_settings_for_fields(

--- a/collab-database/src/rows/row.rs
+++ b/collab-database/src/rows/row.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 use crate::database::{gen_row_id, timestamp};
 use crate::error::DatabaseError;
 use crate::rows::{Cell, Cells, CellsUpdate, RowId, RowMeta, RowMetaUpdate};
-use crate::views::RowOrder;
+use crate::views::{OrderObjectPosition, RowOrder};
 use crate::{impl_bool_update, impl_i32_update, impl_i64_update};
 
 pub type BlockId = i64;
@@ -501,8 +501,7 @@ pub struct CreateRowParams {
   pub cells: Cells,
   pub height: i32,
   pub visibility: bool,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub prev_row_id: Option<RowId>,
+  pub row_position: OrderObjectPosition,
   pub timestamp: i64,
 }
 
@@ -512,12 +511,6 @@ impl CreateRowParamsValidator {
   pub(crate) fn validate(mut params: CreateRowParams) -> Result<CreateRowParams, DatabaseError> {
     if params.id.is_empty() {
       return Err(DatabaseError::InvalidRowID("row_id is empty"));
-    }
-
-    if let Some(prev_row_id) = &params.prev_row_id {
-      if prev_row_id.is_empty() {
-        return Err(DatabaseError::InvalidRowID("prev_row_id is empty"));
-      }
     }
 
     if params.timestamp == 0 {
@@ -535,7 +528,7 @@ impl Default for CreateRowParams {
       cells: Default::default(),
       height: 60,
       visibility: true,
-      prev_row_id: None,
+      row_position: OrderObjectPosition::default(),
       timestamp: 0,
     }
   }
@@ -548,7 +541,7 @@ impl CreateRowParams {
       cells: Cells::default(),
       height: 60,
       visibility: true,
-      prev_row_id: None,
+      row_position: OrderObjectPosition::default(),
       timestamp: timestamp(),
     }
   }

--- a/collab-database/src/rows/row.rs
+++ b/collab-database/src/rows/row.rs
@@ -501,6 +501,7 @@ pub struct CreateRowParams {
   pub cells: Cells,
   pub height: i32,
   pub visibility: bool,
+  #[serde(skip)]
   pub row_position: OrderObjectPosition,
   pub timestamp: i64,
 }

--- a/collab-database/src/views/view.rs
+++ b/collab-database/src/views/view.rs
@@ -229,7 +229,7 @@ impl<'a, 'b> ViewBuilder<'a, 'b> {
   pub fn done(self) {}
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone)]
 pub enum OrderObjectPosition {
   Start,
   Before(String),

--- a/collab-database/src/views/view.rs
+++ b/collab-database/src/views/view.rs
@@ -229,6 +229,15 @@ impl<'a, 'b> ViewBuilder<'a, 'b> {
   pub fn done(self) {}
 }
 
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub enum OrderObjectPosition {
+  Start,
+  Before(String),
+  After(String),
+  #[default]
+  End,
+}
+
 pub struct DatabaseViewUpdate<'a, 'b> {
   map_ref: &'a MapRef,
   txn: &'a mut TransactionMut<'b>,
@@ -263,7 +272,6 @@ impl<'a, 'b> DatabaseViewUpdate<'a, 'b> {
 
   impl_order_update!(
     set_row_orders,
-    push_row_order,
     remove_row_order,
     move_row_order,
     insert_row_order,
@@ -275,7 +283,6 @@ impl<'a, 'b> DatabaseViewUpdate<'a, 'b> {
 
   impl_order_update!(
     set_field_orders,
-    push_field_order,
     remove_field_order,
     move_field_order,
     insert_field_order,
@@ -452,8 +459,8 @@ impl<'a, 'b> DatabaseViewUpdate<'a, 'b> {
   }
 }
 
-pub fn view_id_from_map_ref<T: ReadTxn>(map_ref: &MapRef, txn: &T) -> Option<String> {
-  map_ref.get_str_with_txn(txn, VIEW_ID)
+pub fn view_id_from_map_ref<T: ReadTxn>(map_ref: &MapRef, txn: &T) -> String {
+  map_ref.get_str_with_txn(txn, VIEW_ID).unwrap_or_default()
 }
 
 /// Return a [ViewDescription] from a map ref
@@ -610,33 +617,55 @@ pub trait OrderArray {
     }
   }
 
+  /// Pushes the given object to the front of the array.
+  fn push_front_with_txn(&self, txn: &mut TransactionMut, object: Self::Object) {
+    self.array_ref().push_front(txn, object);
+  }
+
   /// Pushes the given object to the end of the array.
-  fn push_with_txn(&self, txn: &mut TransactionMut, object: Self::Object) {
+  fn push_back_with_txn(&self, txn: &mut TransactionMut, object: Self::Object) {
     self.array_ref().push_back(txn, object);
   }
 
-  /// Insert the given object to the array after the given previous object.
-  /// If the previous object is not found, the object will be inserted to the end of the array.
-  /// If the previous object is None, the object will be inserted to the beginning of the array.
-  fn insert_with_txn(
+  /// Insert the given object to the array before the given previous object.
+  fn insert_before_with_txn(
     &self,
     txn: &mut TransactionMut,
     object: Self::Object,
-    prev_object_id: Option<&String>,
+    next_object_id: &str,
   ) {
-    if let Some(prev_object_id) = prev_object_id {
-      match self.get_position_with_txn(txn, &prev_object_id.to_owned()) {
-        None => {
-          self.array_ref().push_back(txn, object);
-        },
-        Some(pos) => {
-          let next: u32 = pos + 1;
-          self.array_ref().insert(txn, next, object);
-        },
-      }
-    } else {
-      self.array_ref().push_front(txn, object);
-    }
+    match self.get_position_with_txn(txn, next_object_id) {
+      Some(pos) => self.array_ref().insert(txn, pos, object),
+      None => {
+        tracing::warn!(
+          "\"{}\" isn't found in the order array, appending to the end instead",
+          next_object_id
+        );
+        self.array_ref().push_back(txn, object)
+      },
+    };
+  }
+
+  /// Insert the given object to the array after the given previous object.
+  fn insert_after_with_txn(
+    &self,
+    txn: &mut TransactionMut,
+    object: Self::Object,
+    prev_object_id: &str,
+  ) {
+    match self.get_position_with_txn(txn, prev_object_id) {
+      Some(pos) => {
+        let next: u32 = pos + 1;
+        self.array_ref().insert(txn, next, object)
+      },
+      None => {
+        tracing::warn!(
+          "\"{}\" isn't found in the order array, appending to the end instead",
+          prev_object_id
+        );
+        self.array_ref().push_back(txn, object)
+      },
+    };
   }
 
   /// Returns a list of Objects with a transaction.

--- a/collab-database/src/views/view_map.rs
+++ b/collab-database/src/views/view_map.rs
@@ -14,6 +14,8 @@ use crate::views::{
   RowOrderArray, SortMap, ViewBuilder, ViewDescription, FIELD_ORDERS, ROW_ORDERS, VIEW_LAYOUT,
 };
 
+use super::view_id_from_map_ref;
+
 pub struct ViewMap {
   container: MapRefWrapper,
 }
@@ -258,7 +260,7 @@ impl ViewMap {
 
   pub fn update_all_views<F>(&self, f: F)
   where
-    F: Fn(DatabaseViewUpdate),
+    F: Fn(String, DatabaseViewUpdate),
   {
     self
       .container
@@ -267,7 +269,7 @@ impl ViewMap {
 
   pub fn update_all_views_with_txn<F>(&self, txn: &mut TransactionMut, f: F)
   where
-    F: Fn(DatabaseViewUpdate),
+    F: Fn(String, DatabaseViewUpdate),
   {
     let map_refs = self
       .container
@@ -276,9 +278,10 @@ impl ViewMap {
       .collect::<Vec<MapRef>>();
 
     for map_ref in map_refs {
+      let view_id = view_id_from_map_ref(&map_ref, txn);
       let mut update = DatabaseViewUpdate::new(txn, &map_ref);
       update = update.set_modified_at(timestamp());
-      f(update)
+      f(view_id, update)
     }
   }
 

--- a/collab-database/tests/database_test/field_setting_test.rs
+++ b/collab-database/tests/database_test/field_setting_test.rs
@@ -23,7 +23,7 @@ async fn new_field_new_field_setting_test() {
   database_test.create_field(
     None,
     Field::new("f4".to_string(), "text field".to_string(), 0, true),
-    OrderObjectPosition::default(),
+    &OrderObjectPosition::default(),
     default_field_settings_by_layout(),
   );
 

--- a/collab-database/tests/database_test/field_setting_test.rs
+++ b/collab-database/tests/database_test/field_setting_test.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use collab_database::fields::Field;
-use collab_database::views::{CreateViewParams, DatabaseLayout};
+use collab_database::views::{CreateViewParams, DatabaseLayout, OrderObjectPosition};
 
 use crate::database_test::helper::{
   create_database_with_default_data, default_field_settings_by_layout,
@@ -21,7 +21,9 @@ async fn new_field_new_field_setting_test() {
 
   // Create a new field
   database_test.create_field(
+    None,
     Field::new("f4".to_string(), "text field".to_string(), 0, true),
+    OrderObjectPosition::default(),
     default_field_settings_by_layout(),
   );
 

--- a/collab-database/tests/database_test/field_test.rs
+++ b/collab-database/tests/database_test/field_test.rs
@@ -276,4 +276,3 @@ async fn move_field_to_out_of_index_test() {
   assert_eq!(view_1.field_orders[1].id, "f1");
   assert_eq!(view_1.field_orders[2].id, "f2");
 }
-

--- a/collab-database/tests/database_test/field_test.rs
+++ b/collab-database/tests/database_test/field_test.rs
@@ -11,7 +11,7 @@ async fn create_single_field_test() {
   database_test.create_field(
     None,
     Field::new("f1".to_string(), "text field".to_string(), 0, true),
-    OrderObjectPosition::default(),
+    &OrderObjectPosition::default(),
     default_field_settings_by_layout(),
   );
 
@@ -61,7 +61,7 @@ async fn create_multiple_field_test() {
     database_test.create_field(
       None,
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
-      OrderObjectPosition::default(),
+      &OrderObjectPosition::default(),
       default_field_settings_by_layout(),
     );
   }
@@ -84,7 +84,7 @@ async fn create_field_in_view_test() {
     database_test.create_field(
       None,
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
-      OrderObjectPosition::default(),
+      &OrderObjectPosition::default(),
       default_field_settings_by_layout(),
     );
   }
@@ -102,7 +102,7 @@ async fn create_field_in_view_test() {
   database_test.create_field(
     Some("v2"),
     Field::new("f4".to_string(), "text field 4".to_string(), 0, false),
-    OrderObjectPosition::Start,
+    &OrderObjectPosition::Start,
     default_field_settings_by_layout(),
   );
 
@@ -126,7 +126,7 @@ async fn delete_field_test() {
     database_test.create_field(
       None,
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
-      OrderObjectPosition::default(),
+      &OrderObjectPosition::default(),
       default_field_settings_by_layout(),
     );
   }
@@ -143,7 +143,7 @@ async fn delete_field_in_views_test() {
     database_test.create_field(
       None,
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
-      OrderObjectPosition::default(),
+      &OrderObjectPosition::default(),
       default_field_settings_by_layout(),
     );
   }
@@ -175,7 +175,7 @@ async fn field_order_in_view_test() {
     database_test.create_field(
       None,
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
-      OrderObjectPosition::default(),
+      &OrderObjectPosition::default(),
       default_field_settings_by_layout(),
     );
   }
@@ -196,7 +196,7 @@ async fn get_field_in_order_test() {
     database_test.create_field(
       None,
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
-      OrderObjectPosition::default(),
+      &OrderObjectPosition::default(),
       default_field_settings_by_layout(),
     );
   }
@@ -228,7 +228,7 @@ async fn move_field_test() {
     database_test.create_field(
       None,
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
-      OrderObjectPosition::default(),
+      &OrderObjectPosition::default(),
       default_field_settings_by_layout(),
     );
   }
@@ -255,7 +255,7 @@ async fn move_field_to_out_of_index_test() {
     database_test.create_field(
       None,
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
-      OrderObjectPosition::default(),
+      &OrderObjectPosition::default(),
       default_field_settings_by_layout(),
     );
   }

--- a/collab-database/tests/database_test/field_test.rs
+++ b/collab-database/tests/database_test/field_test.rs
@@ -1,5 +1,5 @@
-use collab_database::fields::Field;
 use collab_database::views::CreateViewParams;
+use collab_database::{fields::Field, views::OrderObjectPosition};
 
 use crate::database_test::helper::{
   create_database, create_database_with_default_data, default_field_settings_by_layout,
@@ -9,7 +9,9 @@ use crate::database_test::helper::{
 async fn create_single_field_test() {
   let database_test = create_database(1, "1").await;
   database_test.create_field(
+    None,
     Field::new("f1".to_string(), "text field".to_string(), 0, true),
+    OrderObjectPosition::default(),
     default_field_settings_by_layout(),
   );
 
@@ -57,7 +59,9 @@ async fn create_multiple_field_test() {
   let database_test = create_database(1, "1").await;
   for i in 0..10 {
     database_test.create_field(
+      None,
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
+      OrderObjectPosition::default(),
       default_field_settings_by_layout(),
     );
   }
@@ -71,7 +75,9 @@ async fn delete_field_test() {
   let database_test = create_database(1, "1").await;
   for i in 0..3 {
     database_test.create_field(
+      None,
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
+      OrderObjectPosition::default(),
       default_field_settings_by_layout(),
     );
   }
@@ -86,7 +92,9 @@ async fn delete_field_in_views_test() {
   let database_test = create_database(1, "1").await;
   for i in 0..3 {
     database_test.create_field(
+      None,
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
+      OrderObjectPosition::default(),
       default_field_settings_by_layout(),
     );
   }
@@ -116,7 +124,9 @@ async fn field_order_in_view_test() {
   database_test.create_linked_view(params).unwrap();
   for i in 0..10 {
     database_test.create_field(
+      None,
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
+      OrderObjectPosition::default(),
       default_field_settings_by_layout(),
     );
   }
@@ -135,7 +145,9 @@ async fn get_field_in_order_test() {
   let database_test = create_database(1, "1").await;
   for i in 0..3 {
     database_test.create_field(
+      None,
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
+      OrderObjectPosition::default(),
       default_field_settings_by_layout(),
     );
   }
@@ -165,7 +177,9 @@ async fn move_field_test() {
 
   for i in 0..3 {
     database_test.create_field(
+      None,
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
+      OrderObjectPosition::default(),
       default_field_settings_by_layout(),
     );
   }
@@ -190,7 +204,9 @@ async fn move_field_to_out_of_index_test() {
   let database_test = create_database(1, "1").await;
   for i in 0..3 {
     database_test.create_field(
+      None,
       Field::new(format!("f{}", i), format!("text field {}", i), 0, true),
+      OrderObjectPosition::default(),
       default_field_settings_by_layout(),
     );
   }

--- a/collab-database/tests/database_test/helper.rs
+++ b/collab-database/tests/database_test/helper.rs
@@ -273,19 +273,19 @@ pub async fn create_database_with_default_data(uid: i64, database_id: &str) -> D
   database_test.create_field(
     None,
     field_1,
-    OrderObjectPosition::default(),
+    &OrderObjectPosition::default(),
     field_settings_by_layout.clone(),
   );
   database_test.create_field(
     None,
     field_2,
-    OrderObjectPosition::default(),
+    &OrderObjectPosition::default(),
     field_settings_by_layout.clone(),
   );
   database_test.create_field(
     None,
     field_3,
-    OrderObjectPosition::default(),
+    &OrderObjectPosition::default(),
     field_settings_by_layout,
   );
 

--- a/collab-database/tests/database_test/helper.rs
+++ b/collab-database/tests/database_test/helper.rs
@@ -11,7 +11,7 @@ use collab_database::rows::{CellsBuilder, CreateRowParams};
 use collab_database::user::DatabaseCollabService;
 use collab_database::views::{
   CreateDatabaseParams, DatabaseLayout, FieldSettingsByFieldIdMap, FieldSettingsMap, LayoutSetting,
-  LayoutSettings,
+  LayoutSettings, OrderObjectPosition,
 };
 use collab_entity::CollabType;
 use collab_persistence::kv::rocks_kv::RocksCollabDB;
@@ -232,7 +232,7 @@ pub async fn create_database_with_default_data(uid: i64, database_id: &str) -> D
       .build(),
     height: 0,
     visibility: true,
-    prev_row_id: None,
+    row_position: OrderObjectPosition::default(),
     timestamp: 0,
   };
   let row_2 = CreateRowParams {
@@ -243,7 +243,7 @@ pub async fn create_database_with_default_data(uid: i64, database_id: &str) -> D
       .build(),
     height: 0,
     visibility: true,
-    prev_row_id: None,
+    row_position: OrderObjectPosition::default(),
     timestamp: 0,
   };
   let row_3 = CreateRowParams {
@@ -254,7 +254,7 @@ pub async fn create_database_with_default_data(uid: i64, database_id: &str) -> D
       .build(),
     height: 0,
     visibility: true,
-    prev_row_id: None,
+    row_position: OrderObjectPosition::default(),
     timestamp: 0,
   };
 
@@ -269,9 +269,24 @@ pub async fn create_database_with_default_data(uid: i64, database_id: &str) -> D
 
   let field_settings_by_layout = default_field_settings_by_layout();
 
-  database_test.create_field(field_1, field_settings_by_layout.clone());
-  database_test.create_field(field_2, field_settings_by_layout.clone());
-  database_test.create_field(field_3, field_settings_by_layout);
+  database_test.create_field(
+    None,
+    field_1,
+    OrderObjectPosition::default(),
+    field_settings_by_layout.clone(),
+  );
+  database_test.create_field(
+    None,
+    field_2,
+    OrderObjectPosition::default(),
+    field_settings_by_layout.clone(),
+  );
+  database_test.create_field(
+    None,
+    field_3,
+    OrderObjectPosition::default(),
+    field_settings_by_layout,
+  );
 
   database_test.set_field_settings("v1", field_settings_for_default_database());
 

--- a/collab-database/tests/database_test/type_option_test.rs
+++ b/collab-database/tests/database_test/type_option_test.rs
@@ -134,7 +134,7 @@ async fn insert_multi_type_options_test() {
       type_options,
       ..Default::default()
     },
-    OrderObjectPosition::default(),
+    &OrderObjectPosition::default(),
     default_field_settings_by_layout(),
   );
 

--- a/collab-database/tests/database_test/type_option_test.rs
+++ b/collab-database/tests/database_test/type_option_test.rs
@@ -1,5 +1,6 @@
 use collab::core::any_map::AnyMapExtension;
 use collab_database::fields::{Field, TypeOptionDataBuilder, TypeOptions};
+use collab_database::views::OrderObjectPosition;
 
 use crate::database_test::helper::{
   create_database, default_field_settings_by_layout, DatabaseTest,
@@ -125,6 +126,7 @@ async fn insert_multi_type_options_test() {
   );
 
   test.create_field(
+    None,
     Field {
       id: "f2".to_string(),
       name: "second field".to_string(),
@@ -132,6 +134,7 @@ async fn insert_multi_type_options_test() {
       type_options,
       ..Default::default()
     },
+    OrderObjectPosition::default(),
     default_field_settings_by_layout(),
   );
 

--- a/collab-database/tests/database_test/view_test.rs
+++ b/collab-database/tests/database_test/view_test.rs
@@ -2,7 +2,9 @@ use collab::preclude::lib0Any;
 use collab_database::database::{gen_row_id, DatabaseData};
 use collab_database::fields::Field;
 use collab_database::rows::CreateRowParams;
-use collab_database::views::{CreateViewParams, DatabaseLayout, LayoutSettingBuilder};
+use collab_database::views::{
+  CreateViewParams, DatabaseLayout, LayoutSettingBuilder, OrderObjectPosition,
+};
 use nanoid::nanoid;
 use serde_json::json;
 
@@ -94,11 +96,13 @@ async fn create_database_field_test() {
 
   let field_id = nanoid!(4);
   database_test.create_field(
+    None,
     Field {
       id: field_id.clone(),
       name: "my third field".to_string(),
       ..Default::default()
     },
+    OrderObjectPosition::default(),
     default_field_settings_by_layout(),
   );
 

--- a/collab-database/tests/database_test/view_test.rs
+++ b/collab-database/tests/database_test/view_test.rs
@@ -102,7 +102,7 @@ async fn create_database_field_test() {
       name: "my third field".to_string(),
       ..Default::default()
     },
-    OrderObjectPosition::default(),
+    &OrderObjectPosition::default(),
     default_field_settings_by_layout(),
   );
 

--- a/collab-database/tests/user_test/async_test/row_test.rs
+++ b/collab-database/tests/user_test/async_test/row_test.rs
@@ -1,5 +1,6 @@
 use collab_database::rows::CreateRowParams;
 use collab_database::rows::{CellsBuilder, RowId};
+use collab_database::views::OrderObjectPosition;
 use serde_json::{json, Value};
 
 use collab_plugins::local_storage::CollabPersistenceConfig;
@@ -99,7 +100,7 @@ async fn create_row_test() {
             cells: Default::default(),
             height: 0,
             visibility: false,
-            prev_row_id: None,
+            row_position: OrderObjectPosition::default(),
             timestamp: 0,
           },
         });

--- a/collab-database/tests/user_test/async_test/script.rs
+++ b/collab-database/tests/user_test/async_test/script.rs
@@ -8,7 +8,7 @@ use collab_database::fields::Field;
 use collab_database::rows::CreateRowParams;
 use collab_database::rows::{Cells, CellsBuilder, RowId};
 use collab_database::user::WorkspaceDatabase;
-use collab_database::views::CreateDatabaseParams;
+use collab_database::views::{CreateDatabaseParams, OrderObjectPosition};
 use collab_persistence::doc::YrsDocAction;
 use collab_persistence::kv::rocks_kv::RocksCollabDB;
 use collab_plugins::local_storage::CollabPersistenceConfig;
@@ -198,7 +198,7 @@ pub fn create_database(database_id: &str) -> CreateDatabaseParams {
       .build(),
     height: 0,
     visibility: true,
-    prev_row_id: None,
+    row_position: OrderObjectPosition::default(),
     timestamp: 0,
   };
   let row_2 = CreateRowParams {
@@ -209,7 +209,7 @@ pub fn create_database(database_id: &str) -> CreateDatabaseParams {
       .build(),
     height: 0,
     visibility: true,
-    prev_row_id: None,
+    row_position: OrderObjectPosition::default(),
     timestamp: 0,
   };
   let row_3 = CreateRowParams {
@@ -220,7 +220,7 @@ pub fn create_database(database_id: &str) -> CreateDatabaseParams {
       .build(),
     height: 0,
     visibility: true,
-    prev_row_id: None,
+    row_position: OrderObjectPosition::default(),
     timestamp: 0,
   };
   let field_1 = Field::new("f1".to_string(), "text field".to_string(), 0, true);

--- a/collab-database/tests/user_test/helper.rs
+++ b/collab-database/tests/user_test/helper.rs
@@ -15,7 +15,7 @@ use collab_database::user::{
   CollabFuture, CollabObjectUpdate, CollabObjectUpdateByOid, DatabaseCollabService,
   RowRelationChange, RowRelationUpdateReceiver, WorkspaceDatabase,
 };
-use collab_database::views::{CreateDatabaseParams, DatabaseLayout};
+use collab_database::views::{CreateDatabaseParams, DatabaseLayout, OrderObjectPosition};
 use collab_entity::CollabType;
 use collab_persistence::kv::rocks_kv::RocksCollabDB;
 use collab_plugins::local_storage::rocksdb::RocksdbDiskPlugin;
@@ -177,7 +177,7 @@ fn create_database_params(database_id: &str) -> CreateDatabaseParams {
       .build(),
     height: 0,
     visibility: true,
-    prev_row_id: None,
+    row_position: OrderObjectPosition::default(),
     timestamp: 0,
   };
   let row_2 = CreateRowParams {
@@ -188,7 +188,7 @@ fn create_database_params(database_id: &str) -> CreateDatabaseParams {
       .build(),
     height: 0,
     visibility: true,
-    prev_row_id: None,
+    row_position: OrderObjectPosition::default(),
     timestamp: 0,
   };
   let row_3 = CreateRowParams {
@@ -199,7 +199,7 @@ fn create_database_params(database_id: &str) -> CreateDatabaseParams {
       .build(),
     height: 0,
     visibility: true,
-    prev_row_id: None,
+    row_position: OrderObjectPosition::default(),
     timestamp: 0,
   };
   let field_1 = Field::new("f1".to_string(), "text field".to_string(), 0, true);

--- a/collab-database/tests/user_test/type_option_test.rs
+++ b/collab-database/tests/user_test/type_option_test.rs
@@ -1,6 +1,6 @@
 use collab::core::any_map::AnyMapExtension;
 use collab_database::fields::{Field, TypeOptionDataBuilder, TypeOptions};
-use collab_database::views::CreateDatabaseParams;
+use collab_database::views::{CreateDatabaseParams, OrderObjectPosition};
 
 use crate::database_test::helper::default_field_settings_by_layout;
 use crate::user_test::helper::{workspace_database_test, WorkspaceDatabaseTest};
@@ -45,6 +45,7 @@ async fn insert_multi_type_options_test() {
   );
 
   database.lock().create_field(
+    None,
     Field {
       id: "f2".to_string(),
       name: "second field".to_string(),
@@ -52,6 +53,7 @@ async fn insert_multi_type_options_test() {
       type_options,
       ..Default::default()
     },
+    OrderObjectPosition::default(),
     default_field_settings_by_layout(),
   );
 

--- a/collab-database/tests/user_test/type_option_test.rs
+++ b/collab-database/tests/user_test/type_option_test.rs
@@ -53,7 +53,7 @@ async fn insert_multi_type_options_test() {
       type_options,
       ..Default::default()
     },
-    OrderObjectPosition::default(),
+    &OrderObjectPosition::default(),
     default_field_settings_by_layout(),
   );
 


### PR DESCRIPTION
Allows specifying whether the new object is pushed to the front/back, or before/after a specific object id.

Before:
- specify `prev_object_id` as `None` to push to the front, which isn't immediately clear.
- specify invalid `prev_object_id` will push back the object, leading to writing code in hacky ways, such as explicitly sending `""` as the `object_id`.
- specify `prev_object_id` to insert the object after that id.

After:
- specify `OrderObjectPosition::Start` or `OrderObjectPosition::End` to push front or back, respectively
- specify `OrderObjectPosition::Before(<object_id>)` or `OrderObjectPosition::After(<object_id>)` to insert the object relative to the `object_id`