### PR TITLE
fix: remove inaccurate filter test and remove get_filter_by_field_id

### DIFF
--- a/collab-database/src/database.rs
+++ b/collab-database/src/database.rs
@@ -887,26 +887,6 @@ impl Database {
     }
   }
 
-  pub fn get_filter_by_field_id<T: TryFrom<FilterMap>>(
-    &self,
-    view_id: &str,
-    field_id: &str,
-  ) -> Option<T> {
-    let field_id = field_id.to_string();
-    let mut filters = self
-      .views
-      .get_view_filters(view_id)
-      .into_iter()
-      .filter(|filter_map| filter_map.get_str_value("field_id").as_ref() == Some(&field_id))
-      .flat_map(|value| T::try_from(value).ok())
-      .collect::<Vec<T>>();
-    if filters.is_empty() {
-      None
-    } else {
-      Some(filters.remove(0))
-    }
-  }
-
   pub fn update_filter(&self, view_id: &str, filter_id: &str, f: impl FnOnce(&mut FilterMap)) {
     self.views.update_database_view(view_id, |view_update| {
       view_update.update_filters(|filter_update| {

--- a/collab-database/tests/database_test/filter_test.rs
+++ b/collab-database/tests/database_test/filter_test.rs
@@ -49,20 +49,10 @@ async fn insert_or_update_database_view_filter_test() {
 }
 
 #[tokio::test]
-async fn get_database_view_filter_by_field_id_test() {
-  let database_test = create_database_with_two_filters().await;
-  let filter_1 = database_test
-    .get_filter_by_field_id::<TestFilter>("v1", "f1")
-    .unwrap();
-  assert_eq!(filter_1.content, "hello filter");
-}
-
-#[tokio::test]
-async fn insert_database_view_filter_with_occupied_field_id_test() {
+async fn insert_database_view_filter_to_filtering_field_id_test() {
   let database_test = create_database_with_two_filters().await;
 
-  // The field id "f1" is already occupied by existing filter. So this filter
-  // will be ignored
+  // Filter with id "filter_1" already filters based on "f1"
   database_test.insert_filter(
     "v1",
     TestFilter {
@@ -70,14 +60,14 @@ async fn insert_database_view_filter_with_occupied_field_id_test() {
       field_id: "f1".to_string(),
       field_type: Default::default(),
       condition: 0,
-      content: "Override the existing filter".to_string(),
+      content: "Another filter".to_string(),
     },
   );
 
-  let filter_1 = database_test
-    .get_filter_by_field_id::<TestFilter>("v1", "f1")
+  let filter_3 = database_test
+    .get_filter::<TestFilter>("v1", "filter_3")
     .unwrap();
-  assert_eq!(filter_1.content, "hello filter");
+  assert_eq!(filter_3.content, "Another filter");
 }
 
 #[tokio::test]


### PR DESCRIPTION
The test `insert_database_view_filter_with_occupied_field_id_test` is inaccurate.

Inserting a filter with a `field_id` that is already the `field_id` of another filter doesn't ignore it, but still pushes instead. The test passes because the `get_filter_by_field_id` function returns only the first filter of the `ArrayRef`.

Also removing that function in particular, since the context should only know of an `id` field and leave the rest of the fields up to the filter implementation, whether it is a `Filter` in `flowy-database2` or a `TestFilter` in the tests. 