### PR TITLE
chore: update to yrs v0.18.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2172,9 +2172,9 @@ checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "yrs"
-version = "0.18.7"
+version = "0.18.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58fbc807677598fedfab76f99f6e1aa5c644411255002b5438ea0ab14672398"
+checksum = "da227d69095141c331d9b60c11496d0a3c6505cd9f8e200898b197219e8e394f"
 dependencies = [
  "arc-swap",
  "atomic_refcell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ collab-user = { workspace = true, path = "collab-user" }
 collab-entity = { workspace = true, path = "collab-entity" }
 collab-document = { workspace = true, path = "collab-document" }
 collab-folder = { workspace = true, path = "collab-folder" }
-yrs = "0.18.7"
+yrs = "0.18.8"
 anyhow = "1.0"
 thiserror = "1.0.39"
 serde = { version = "1.0.157", features = ["derive"] }

--- a/collab/src/core/collab.rs
+++ b/collab/src/core/collab.rs
@@ -705,11 +705,11 @@ fn observe_awareness(
   origin: CollabOrigin,
 ) -> Subscription {
   awareness.on_update(move |event| {
-    if let Some(update) = event.awareness_update() {
+    if let Ok(update) = event.awareness_state().full_update() {
       plugins
         .read()
         .iter()
-        .for_each(|plugin| plugin.receive_local_state(&origin, &oid, event, update));
+        .for_each(|plugin| plugin.receive_local_state(&origin, &oid, event, &update));
     }
   })
 }


### PR DESCRIPTION
1. This PR upgrades yrs dependency to v0.18.8.
2. It also changes the behaviour of awareness update observer to what it was before #216 : now it will generate full awareness state update instead of just latest modifications.