### PR TITLE
chore: use native impl of yrs apply delta

### DIFF
--- a/collab-document/src/blocks/block.rs
+++ b/collab-document/src/blocks/block.rs
@@ -128,20 +128,20 @@ impl BlockOperation {
 
     // Update parent field with the given parent id.
     if let Some(parent_id) = parent_id {
-      map.insert_with_txn(txn, PARENT, parent_id);
+      map.try_update(txn, PARENT, parent_id);
     }
     // Update data field with the given data.
     if let Some(data) = data {
-      map.insert_with_txn(txn, DATA, hashmap_to_json_str(data)?);
+      map.try_update(txn, DATA, hashmap_to_json_str(data)?);
     }
 
     // Update external id and external type.
     if let Some(external_id) = external_id {
-      map.insert_with_txn(txn, EXTERNAL_ID, external_id);
+      map.try_update(txn, EXTERNAL_ID, external_id);
     }
 
     if let Some(external_type) = external_type {
-      map.insert_with_txn(txn, EXTERNAL_TYPE, external_type);
+      map.try_update(txn, EXTERNAL_TYPE, external_type);
     }
     Ok(())
   }

--- a/collab-document/src/blocks/text_entities.rs
+++ b/collab-document/src/blocks/text_entities.rs
@@ -1,12 +1,13 @@
-use collab::preclude::{Any, Attrs, Delta, ReadTxn, YrsValue};
-use serde::de::{self, Deserialize, Deserializer, MapAccess, Visitor};
-use serde::ser::SerializeMap;
-use serde::{Serialize, Serializer};
 use std::collections::HashMap;
 use std::fmt;
 use std::ops::Deref;
-
 use std::sync::Arc;
+
+use serde::de::{self, Deserialize, Deserializer, MapAccess, Visitor};
+use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
+
+use collab::preclude::{Any, Attrs, Delta, ReadTxn, YrsInput};
 
 const FIELD_INSERT: &str = "insert";
 const FIELD_DELETE: &str = "delete";
@@ -56,10 +57,10 @@ impl TextDelta {
     }
   }
 
-  pub fn to_delta(self) -> Delta {
+  pub fn to_delta(self) -> Delta<YrsInput> {
     match self {
       Self::Inserted(content, attrs) => {
-        let content = YrsValue::from(content);
+        let content = YrsInput::from(content);
         Delta::Inserted(content, attrs.map(Box::new))
       },
       Self::Deleted(len) => Delta::Deleted(len),

--- a/collab-document/tests/blocks/text_test.rs
+++ b/collab-document/tests/blocks/text_test.rs
@@ -293,26 +293,27 @@ async fn delta_equal_test() {
 
 #[tokio::test]
 async fn text_delta_trans_delta_test() {
+  use collab::preclude::AsPrelim;
   let test = BlockTestCore::new().await;
   test.document.with_transact_mut(|txn| {
     let text_delta = TextDelta::Inserted("Hello World".to_string(), None);
     let delta = Delta::Inserted(YrsValue::from("Hello World"), None);
     let result = TextDelta::from(txn, delta.clone());
     assert_eq!(result, text_delta);
-    assert_eq!(result.to_delta(), delta);
+    assert_eq!(result.to_delta(), delta.map(|v| v.as_prelim(txn)));
 
     let attrs = Attrs::from([(Arc::from("bold"), true.into())]);
     let delta = Delta::Retain(6, Some(Box::from(attrs.clone())));
     let result = TextDelta::from(txn, delta.clone());
     let text_delta = TextDelta::Retain(6, Some(attrs));
     assert_eq!(result, text_delta);
-    assert_eq!(result.to_delta(), delta);
+    assert_eq!(result.to_delta(), delta.map(|v| v.as_prelim(txn)));
 
     let delta = Delta::Deleted(4);
     let result = TextDelta::from(txn, delta.clone());
     let text_delta = TextDelta::Deleted(4);
     assert_eq!(result, text_delta);
-    assert_eq!(result.to_delta(), delta);
+    assert_eq!(result.to_delta(), delta.map(|v| v.as_prelim(txn)));
   })
 }
 

--- a/collab/src/lib.rs
+++ b/collab/src/lib.rs
@@ -23,8 +23,9 @@ pub mod preclude {
   pub use serde_json::value::Value as JsonValue;
   pub use yrs::block::Prelim;
   pub use yrs::types::{
-    array::Array, Attrs, Delta as YrsDelta, EntryChange, GetString, Observable, ToJson, *,
+    array::Array, AsPrelim, Attrs, Delta as YrsDelta, EntryChange, GetString, Observable, ToJson, *,
   };
+  pub use yrs::In as YrsInput;
   pub use yrs::Out as YrsValue;
   pub use yrs::*;
 


### PR DESCRIPTION
Changes:

1. Replace custom implementation of `Text::apply_delta` with a native one (introduced in yrs 0.19).
2. Update block only if its contents are different from current document state.