### PR TITLE
feat: use js_sys to obtain clock time for wasm

### DIFF
--- a/collab/src/core/collab.rs
+++ b/collab/src/core/collab.rs
@@ -117,11 +117,7 @@ pub struct WebClock;
 #[cfg(target_arch = "wasm32")]
 impl Clock for WebClock {
   fn now(&self) -> Timestamp {
-    let window = web_sys::window().expect("should have a window in this context");
-    let performance = window
-      .performance()
-      .expect("performance should be available");
-    performance.now() as u64
+    js_sys::Date::now() as u64
   }
 }
 


### PR DESCRIPTION
As system time for rust std library is not meant to be used in browser environment, certain methods are disabled on the yrs library if the compilation target arch is wasm32. Therefore, to avoid compilation error for client-api-wasm, we will need to use web sys to obtain the system time instead.