### PR TITLE
fix: lazy load anyhow & timestamp in section_item

### DIFF
--- a/collab-folder/src/section.rs
+++ b/collab-folder/src/section.rs
@@ -364,8 +364,8 @@ impl TryFrom<AnyMap> for SectionItem {
   fn try_from(value: AnyMap) -> Result<Self, Self::Error> {
     let id = value
       .get_str_value("id")
-      .ok_or(anyhow::anyhow!("missing section item id"))?;
-    let timestamp = value.get_i64_value("timestamp").unwrap_or(timestamp());
+      .ok_or_else(|| anyhow::anyhow!("missing section item id"))?;
+    let timestamp = value.get_i64_value("timestamp").unwrap_or_else(timestamp);
     Ok(Self { id, timestamp })
   }
 }


### PR DESCRIPTION
optimize the `try_from` function to reduce the time from 100-200us to 2-3us

<img width="188" alt="Screenshot 2024-08-13 at 11 11 04" src="https://github.com/user-attachments/assets/0c209405-2f5f-4226-9548-c41b1639e425">
<img width="368" alt="Screenshot 2024-08-13 at 11 11 38" src="https://github.com/user-attachments/assets/12d9971b-aecc-419c-88f8-c3ae86c1db73">
