### PR TITLE
chore: add tracing for persisted entries stored by rocks db plugin

### DIFF
--- a/collab-plugins/Cargo.toml
+++ b/collab-plugins/Cargo.toml
@@ -63,3 +63,4 @@ wasm-bindgen-test = "0.3.40"
 [features]
 default = []
 postgres_plugin = ["rand"]
+verbose_log = []


### PR DESCRIPTION
This PR add logging to updates and and snapshots persisted by RocksDB plugin. It also provides a `verbose_log` feature flag - when that flag is active we also will log contents of individual updates.


This is to better inspect what's stored onto disk in the future. I've observed that when using appflowy frontend app, sometimes a few user actions can cause 80-90 updates to be persisted.