### PR TITLE
chore: remove last sync at field from collab

### DIFF
--- a/collab-plugins/src/cloud_storage/postgres/plugin.rs
+++ b/collab-plugins/src/cloud_storage/postgres/plugin.rs
@@ -80,7 +80,7 @@ impl SupabaseDBPlugin {
 }
 
 impl CollabPlugin for SupabaseDBPlugin {
-  fn did_init(&self, _collab: &Collab, _object_id: &str, _last_sync_at: i64) {
+  fn did_init(&self, _collab: &Collab, _object_id: &str) {
     // TODO(nathan): retry action might take a long time even if the network is ready or enable of
     // the [RemoteCollabStorage] is true
     let retry_strategy = FibonacciBackoff::from_millis(2000);

--- a/collab-plugins/src/local_storage/kv/doc.rs
+++ b/collab-plugins/src/local_storage/kv/doc.rs
@@ -127,6 +127,13 @@ where
           object_id
         );
       }
+
+      tracing::trace!(
+        "Collab {:?} loaded from snapshot and {} updates",
+        object_id,
+        update_count
+      );
+
       Ok(update_count)
     } else {
       tracing::trace!("[Client] => {:?} not exist", object_id);

--- a/collab-plugins/src/local_storage/rocksdb/rocksdb_plugin.rs
+++ b/collab-plugins/src/local_storage/rocksdb/rocksdb_plugin.rs
@@ -83,7 +83,7 @@ impl RocksdbDiskPlugin {
 }
 
 impl CollabPlugin for RocksdbDiskPlugin {
-  fn did_init(&self, collab: &Collab, object_id: &str, _last_sync_at: i64) {
+  fn did_init(&self, collab: &Collab, object_id: &str) {
     self.did_init.store(true, SeqCst);
 
     if let Some(collab_db) = self.collab_db.upgrade() {

--- a/collab/src/core/collab.rs
+++ b/collab/src/core/collab.rs
@@ -33,8 +33,6 @@ use crate::preclude::JsonValue;
 pub const DATA_SECTION: &str = "data";
 pub const META_SECTION: &str = "meta";
 
-const LAST_SYNC_AT: &str = "last_sync_at";
-
 type AfterTransactionSubscription = Subscription;
 
 pub type MapSubscriptionCallback = Arc<dyn Fn(&TransactionMut, &MapEvent)>;
@@ -356,11 +354,10 @@ impl Collab {
       .awareness_subscription
       .store(Some(awareness_subscription.into()));
 
-    let last_sync_at = self.get_last_sync_at();
     {
       self
         .plugins
-        .each(|plugin| plugin.did_init(self, &self.object_id, last_sync_at));
+        .each(|plugin| plugin.did_init(self, &self.object_id));
     }
     self.state.set_init_state(InitState::Initialized);
   }
@@ -486,24 +483,6 @@ impl Collab {
   pub fn encode_collab_v2(&self) -> EncodedCollab {
     let tx = self.context.transact();
     tx.get_encoded_collab_v2()
-  }
-
-  pub fn get_last_sync_at(&self) -> i64 {
-    let txn = self.context.transact();
-    self
-      .meta
-      .get(&txn, LAST_SYNC_AT)
-      .and_then(|v| v.cast().ok())
-      .unwrap_or(0)
-  }
-
-  pub fn set_last_sync_at(&mut self, last_sync_at: i64) {
-    //FIXME: this is very expensive to do on frequent basis. That's one of the reasons we have
-    // awareness state separate from document
-    let mut txn = self.context.transact_mut();
-    self
-      .meta
-      .insert(&mut txn, LAST_SYNC_AT, Any::BigInt(last_sync_at));
   }
 
   pub fn to_json(&self) -> Any {

--- a/collab/src/core/collab_plugin.rs
+++ b/collab/src/core/collab_plugin.rs
@@ -37,7 +37,7 @@ pub trait CollabPlugin: Send + Sync + 'static {
   fn init(&self, _object_id: &str, _origin: &CollabOrigin, _doc: &Doc) {}
 
   /// Called when the plugin is initialized.
-  fn did_init(&self, _collab: &Collab, _object_id: &str, _last_sync_at: i64) {}
+  fn did_init(&self, _collab: &Collab, _object_id: &str) {}
 
   /// Called when the plugin receives an update. It happens after the [TransactionMut] commit to
   /// the Yrs document.
@@ -87,8 +87,8 @@ where
     (**self).init(object_id, origin, doc);
   }
 
-  fn did_init(&self, collab: &Collab, _object_id: &str, last_sync_at: i64) {
-    (**self).did_init(collab, _object_id, last_sync_at)
+  fn did_init(&self, collab: &Collab, _object_id: &str) {
+    (**self).did_init(collab, _object_id)
   }
 
   fn receive_update(&self, object_id: &str, txn: &TransactionMut, update: &[u8]) {


### PR DESCRIPTION
This PR removes `/meta/last_sync_at` field from collab along with its getters and setters. The reason for that is that setting these fields will trigger circular reaction of yrs doc updates that can easily become the majority of updates persisted and exchanged between client and server.

Also, this field data was never used for any practical purposes.