### PR TITLE
chore: enable to get document data straight from collab

### DIFF
--- a/collab/src/core/collab.rs
+++ b/collab/src/core/collab.rs
@@ -454,7 +454,6 @@ impl Collab {
 
   pub fn enable_undo_redo(&mut self) {
     if self.context.undo_manager.is_some() {
-      tracing::warn!("Undo manager already enabled");
       return;
     }
     // a frequent case includes establishing a new transaction for every user key stroke. Meanwhile


### PR DESCRIPTION
This PR enables us to create `DocumentBody` straight from the `Collab` in readonly mode. The reason for that is that sometimes we want to be able to execute `Document`-specific operations without having direct access to a `Document` instance. Example: on the server side, we don't distinguish between different collab types, yet document indexer should be able to access `Document`-specific API.