### PR TITLE
chore: refactor inline view id

### DIFF
--- a/collab-database/Cargo.toml
+++ b/collab-database/Cargo.toml
@@ -53,6 +53,7 @@ tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 rand = "0.8.4"
 futures = "0.3.30"
 zip = "0.6.6"
+tokio = { version = "1.38", features = ["full"] }
 
 
 [features]

--- a/collab-database/src/blocks/block.rs
+++ b/collab-database/src/blocks/block.rs
@@ -140,6 +140,11 @@ impl Block {
     )?;
 
     let database_row = Arc::new(RwLock::from(database_row));
+    if let Some(persistence) = self.collab_service.persistence() {
+      if let Ok(encoded_collab) = database_row.write().await.encoded_collab() {
+        persistence.save_collab(&row_id, encoded_collab)?;
+      }
+    }
     self.row_mem_cache.insert(row_id, database_row);
     Ok(row_order)
   }

--- a/collab-database/src/database.rs
+++ b/collab-database/src/database.rs
@@ -321,7 +321,13 @@ impl Database {
   /// Return all field orders without order
   pub fn get_all_field_orders(&self) -> Vec<FieldOrder> {
     let txn = self.collab.transact();
-    self.body.fields.get_all_field_orders(&txn)
+    match self.body.try_get_inline_view_id(&txn) {
+      None => {
+        error!("Cannot find inline view id");
+        self.body.fields.get_all_field_orders(&txn)
+      },
+      Some(inline_view_id) => self.body.views.get_field_orders(&txn, &inline_view_id),
+    }
   }
 
   pub fn get_all_views(&self) -> Vec<DatabaseView> {

--- a/collab-database/src/database.rs
+++ b/collab-database/src/database.rs
@@ -85,10 +85,11 @@ impl DatabaseContext {
   }
 }
 
-pub fn default_database_data(database_id: &str) -> Result<EncodedCollab, DatabaseError> {
+pub async fn default_database_data(database_id: &str) -> Result<EncodedCollab, DatabaseError> {
   let context = DatabaseContext::new(Arc::new(NoPersistenceDatabaseCollabService));
   let collab = Collab::new_with_origin(CollabOrigin::Empty, database_id, vec![], false);
-  let (_, collab) = DatabaseBody::create(collab, database_id.to_string(), context)?;
+  let (_, collab) =
+    DatabaseBody::create(collab, database_id.to_string(), context, vec![], vec![]).await?;
   Ok(
     collab
       .encode_collab_v1(|_collab| Ok::<_, DatabaseError>(()))
@@ -108,7 +109,7 @@ impl Database {
       .build_collab(database_id, CollabType::Database, None)
       .await?;
     let collab_service = context.collab_service.clone();
-    let (body, collab) = DatabaseBody::open(collab, database_id.to_string(), context)?;
+    let (body, collab) = DatabaseBody::open(collab, context)?;
     Ok(Self {
       collab,
       body,
@@ -116,12 +117,17 @@ impl Database {
     })
   }
 
-  pub async fn create(database_id: &str, context: DatabaseContext) -> Result<Self, DatabaseError> {
+  pub async fn create(
+    database_id: &str,
+    context: DatabaseContext,
+    rows: Vec<CreateRowParams>,
+    fields: Vec<Field>,
+  ) -> Result<Self, DatabaseError> {
     if database_id.is_empty() {
       return Err(DatabaseError::InvalidDatabaseID("database_id is empty"));
     }
 
-    let encoded_collab = default_database_data(database_id)?;
+    let encoded_collab = default_database_data(database_id).await?;
     let collab = context
       .collab_service
       .build_collab(
@@ -132,7 +138,8 @@ impl Database {
       .await?;
 
     let collab_service = context.collab_service.clone();
-    let (body, collab) = DatabaseBody::create(collab, database_id.to_string(), context)?;
+    let (body, collab) =
+      DatabaseBody::create(collab, database_id.to_string(), context, rows, fields).await?;
     Ok(Self {
       collab,
       body,
@@ -169,8 +176,30 @@ impl Database {
     context: DatabaseContext,
   ) -> Result<Self, DatabaseError> {
     // Get or create empty database with the given database_id
-    let mut database = Self::create(&params.database_id, context).await?;
-    database.create_view(params).await?;
+    let CreateDatabaseParams {
+      database_id,
+      rows,
+      fields,
+      views,
+    } = params;
+
+    let mut database = Self::create(&database_id, context, rows, fields).await?;
+    let row_orders = database.get_all_row_orders().await;
+    let field_orders = database.get_all_field_orders();
+    {
+      let mut txn = database.collab.context.transact_mut();
+
+      // create the linked views
+      for linked_view in views {
+        database.body.create_linked_view(
+          &mut txn,
+          linked_view,
+          field_orders.clone(),
+          row_orders.clone(),
+        )?;
+      }
+    }
+
     tokio::task::spawn_blocking(move || {
       database.write_to_disk()?;
       Ok::<_, DatabaseError>(database)
@@ -256,61 +285,6 @@ impl Database {
     Ok(())
   }
 
-  async fn create_view(&mut self, params: CreateDatabaseParams) -> Result<(), DatabaseError> {
-    let CreateDatabaseParams {
-      database_id: _,
-      rows,
-      fields,
-      inline_view_id,
-      mut views,
-    } = params;
-
-    let inline_view =
-      if let Some(index) = views.iter().position(|view| view.view_id == inline_view_id) {
-        views.remove(index)
-      } else {
-        return Err(DatabaseError::DatabaseViewNotExist);
-      };
-
-    // create rows
-    let row_orders = self.body.block.create_rows(rows).await;
-
-    // create fields
-    let field_orders: Vec<FieldOrder> = fields.iter().map(FieldOrder::from).collect();
-
-    let mut txn = self.collab.context.transact_mut();
-    // Set the inline view id. The inline view id should not be
-    // empty if the current database exists.
-    info!("Set inline view id: {}", inline_view_id);
-    self
-      .body
-      .metas
-      .set_inline_view_id(&mut txn, &inline_view_id);
-
-    // Insert the given fields into the database
-    for field in fields {
-      self.body.fields.insert_field(&mut txn, field);
-    }
-    // Create the inline view
-    self.body.create_view(
-      &mut txn,
-      inline_view,
-      field_orders.clone(),
-      row_orders.clone(),
-    )?;
-
-    // create the linked views
-    for linked_view in views {
-      self.body.create_linked_view(
-        &mut txn,
-        linked_view,
-        field_orders.clone(),
-        row_orders.clone(),
-      )?;
-    }
-    Ok(())
-  }
-
   pub fn validate(&self) -> Result<(), DatabaseError> {
     CollabType::Database.validate_require_data(&self.collab)?;
     Ok(())
@@ -352,7 +326,13 @@ impl Database {
 
   pub fn get_all_views(&self) -> Vec<DatabaseView> {
     let txn = self.collab.transact();
-    self.body.views.get_all_views(&txn)
+    self
+      .body
+      .views
+      .get_all_views(&txn)
+      .into_iter()
+      .filter(|view| !view.is_inline)
+      .collect()
   }
 
   pub fn get_database_view_layout(&self, view_id: &str) -> DatabaseLayout {
@@ -1228,7 +1208,13 @@ impl Database {
   // TODO (RS): Implement the creation of a default view when fetching all database views returns an empty result, with the exception of inline views.
   pub fn get_all_database_views_meta(&self) -> Vec<DatabaseViewMeta> {
     let txn = self.collab.transact();
-    self.body.views.get_all_views_meta(&txn)
+    self
+      .body
+      .views
+      .get_all_views_meta(&txn)
+      .into_iter()
+      .filter(|view| !view.is_inline)
+      .collect()
   }
 
   /// Create a linked view to existing database
@@ -1332,7 +1318,7 @@ impl Database {
 
     let database_id = self.body.get_database_id(&txn);
     let inline_view_id = self.body.get_inline_view_id(&txn);
-    let views = self.body.views.get_all_views(&txn);
+    let views = self.get_all_views();
     let fields = self.body.get_fields_in_view(&txn, &inline_view_id, None);
     let rows_stream = self.get_all_rows(None).await;
     let rows: Vec<Row> = rows_stream
@@ -1637,19 +1623,19 @@ pub struct DatabaseBody {
 }
 
 impl DatabaseBody {
-  fn open(
-    collab: Collab,
-    database_id: String,
-    context: DatabaseContext,
-  ) -> Result<(Self, Collab), DatabaseError> {
+  fn open(collab: Collab, context: DatabaseContext) -> Result<(Self, Collab), DatabaseError> {
     CollabType::Database.validate_require_data(&collab)?;
-    Self::create(collab, database_id, context)
+    let body = Self::from_collab(&collab, context.collab_service)
+      .ok_or_else(|| DatabaseError::NoRequiredData("Can not open database".to_string()))?;
+    Ok((body, collab))
   }
 
-  fn create(
+  async fn create(
     mut collab: Collab,
     database_id: String,
     context: DatabaseContext,
+    new_rows: Vec<CreateRowParams>,
+    new_fields: Vec<Field>,
   ) -> Result<(Self, Collab), DatabaseError> {
     let origin = collab.origin().clone();
     let mut txn = collab.context.transact_mut();
@@ -1658,16 +1644,45 @@ impl DatabaseBody {
     let fields: MapRef = root.get_or_init(&mut txn, FIELDS); // { DATABASE: { FIELDS: {:} } }
     let views: MapRef = root.get_or_init(&mut txn, VIEWS); // { DATABASE: { FIELDS: {:}, VIEWS: {:} } }
     let metas: MapRef = root.get_or_init(&mut txn, DATABASE_METAS); // { DATABASE: { FIELDS: {:},  VIEWS: {:}, METAS: {:} } }
-    drop(txn);
 
     let fields = FieldMap::new(fields, Some(context.notifier.field_change_tx.clone()));
     let views = DatabaseViews::new(origin, views, Some(context.notifier.view_change_tx.clone()));
-    let metas = MetaMap::new(metas);
     let block = Block::new(
-      database_id,
+      database_id.clone(),
       context.collab_service.clone(),
       Some(context.notifier.row_change_tx.clone()),
     );
+
+    let database_id_uuid = Uuid::parse_str(&database_id)
+      .map_err(|_| DatabaseError::InvalidDatabaseID("database_id is not a valid UUID"))?;
+    let inline_view_id = database_inline_view_id(&database_id_uuid);
+
+    // create rows
+    let row_orders = block.create_rows(new_rows).await;
+
+    // create field orders
+    let field_orders: Vec<FieldOrder> = new_fields.iter().map(FieldOrder::from).collect();
+
+    // Insert the given fields into the database
+    for field in new_fields {
+      fields.insert_field(&mut txn, field);
+    }
+
+    let mut inline_view = DatabaseView::new(
+      database_id,
+      inline_view_id.to_string(),
+      "".to_string(),
+      DatabaseLayout::Grid,
+    );
+    inline_view.is_inline = true;
+    inline_view.row_orders = row_orders.clone();
+    inline_view.field_orders = field_orders.clone();
+    views.insert_view(&mut txn, inline_view);
+
+    let metas = MetaMap::new(metas);
+    metas.set_inline_view_id(&mut txn, &inline_view_id.to_string());
+    drop(txn);
+
     let body = DatabaseBody {
       root,
       views: views.into(),
@@ -1683,7 +1698,10 @@ impl DatabaseBody {
   /// present, it will return `None`.
   ///
   /// There is no [DatabaseNotify] or persistence layer in [DatabaseBody] created by this method.
-  pub fn from_collab(collab: &Collab) -> Option<Self> {
+  pub fn from_collab(
+    collab: &Collab,
+    collab_service: Arc<dyn DatabaseCollabService>,
+  ) -> Option<Self> {
     let txn = collab.context.transact();
     let root: MapRef = collab.data.get_with_txn(&txn, DATABASE)?;
     let database_id = root.get_with_txn(&txn, DATABASE_ID)?;
@@ -1694,11 +1712,7 @@ impl DatabaseBody {
     let fields = FieldMap::new(fields, None);
     let views = DatabaseViews::new(CollabOrigin::Empty, views, None);
     let metas = MetaMap::new(metas);
-    let block = Block::new(
-      database_id,
-      Arc::new(NoPersistenceDatabaseCollabService),
-      None,
-    );
+    let block = Block::new(database_id, collab_service, None);
     Some(Self {
       root,
       views: views.into(),
@@ -1936,6 +1950,7 @@ impl DatabaseBody {
       field_orders,
       created_at: params.created_at,
       modified_at: params.modified_at,
+      is_inline: false,
     };
     // tracing::trace!("create linked view with params {:?}", params);
     self.views.insert_view(txn, view);
@@ -2004,4 +2019,9 @@ pub fn try_fixing_database(
   }
 
   Ok(())
+}
+
+fn database_inline_view_id(database_id: &Uuid) -> Uuid {
+  let key = "inline_view_id";
+  Uuid::new_v5(database_id, key.as_bytes())
 }

--- a/collab-database/src/database.rs
+++ b/collab-database/src/database.rs
@@ -1328,7 +1328,6 @@ impl Database {
 
     DatabaseData {
       database_id,
-      inline_view_id,
       fields,
       rows,
       views,
@@ -1503,7 +1502,6 @@ pub fn timestamp() -> i64 {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct DatabaseData {
   pub database_id: String,
-  pub inline_view_id: String,
   pub views: Vec<DatabaseView>,
   pub fields: Vec<Field>,
   pub rows: Vec<Row>,

--- a/collab-database/src/fields/field_map.rs
+++ b/collab-database/src/fields/field_map.rs
@@ -95,7 +95,6 @@ impl FieldMap {
   }
 
   /// Get all field orders with a transaction
-  /// This is used to get the order of fields in the view
   pub fn get_all_field_orders<T: ReadTxn>(&self, txn: &T) -> Vec<FieldOrder> {
     self
       .container

--- a/collab-database/src/template/util.rs
+++ b/collab-database/src/template/util.rs
@@ -34,7 +34,6 @@ where
 pub(crate) fn create_database_params_from_template(
   template: DatabaseTemplate,
 ) -> CreateDatabaseParams {
-  let inline_view_id = template.view_id;
   let database_id = template.database_id;
   let timestamp = timestamp();
 
@@ -70,7 +69,7 @@ pub(crate) fn create_database_params_from_template(
   for view_template in template.views {
     views.push(CreateViewParams {
       database_id: database_id.clone(),
-      view_id: inline_view_id.clone(),
+      view_id: template.view_id.clone(),
       name: view_template.name,
       layout: view_template.layout,
       layout_settings: view_template.layout_settings,
@@ -87,7 +86,6 @@ pub(crate) fn create_database_params_from_template(
 
   CreateDatabaseParams {
     database_id,
-    inline_view_id,
     fields,
     rows,
     views,

--- a/collab-database/src/views/define.rs
+++ b/collab-database/src/views/define.rs
@@ -11,4 +11,5 @@ pub const DATABASE_VIEW_ROW_ORDERS: &str = "row_orders";
 pub const DATABASE_VIEW_FIELD_ORDERS: &str = "field_orders";
 pub const VIEW_CREATE_AT: &str = "created_at";
 pub const VIEW_MODIFY_AT: &str = "modified_at";
+pub const IS_INLINE: &str = "is_inline";
 pub const VIEW_CALCULATIONS: &str = "calculations";

--- a/collab-database/src/views/mod.rs
+++ b/collab-database/src/views/mod.rs
@@ -1,6 +1,6 @@
 mod calculation;
 pub mod define;
-mod field_order;
+pub mod field_order;
 mod field_settings;
 mod filter;
 mod group;

--- a/collab-database/src/views/view.rs
+++ b/collab-database/src/views/view.rs
@@ -62,6 +62,11 @@ impl<'a, 'b> DatabaseViewUpdate<'a, 'b> {
     self
   }
 
+  pub fn set_is_inline(self, is_inline: bool) -> Self {
+    self.map_ref.insert(self.txn, IS_INLINE, is_inline);
+    self
+  }
+
   impl_str_update!(
     set_database_id,
     set_database_id_if_not_none,
@@ -281,7 +286,12 @@ pub fn view_meta_from_value<T: ReadTxn>(value: YrsValue, txn: &T) -> Option<Data
   let map_ref: MapRef = value.cast().ok()?;
   let id: String = map_ref.get_with_txn(txn, VIEW_ID)?;
   let name: String = map_ref.get_with_txn(txn, VIEW_NAME).unwrap_or_default();
-  Some(DatabaseViewMeta { id, name })
+  let is_inline = map_ref.get_with_txn(txn, IS_INLINE).unwrap_or_default();
+  Some(DatabaseViewMeta {
+    id,
+    name,
+    is_inline,
+  })
 }
 
 /// Return a [DatabaseView] from a map ref
@@ -405,6 +415,8 @@ pub fn view_from_map_ref<T: ReadTxn>(map_ref: &MapRef, txn: &T) -> Option<Databa
     .map(|map_ref| FieldSettingsByFieldIdMap::from((txn, &map_ref)))
     .unwrap_or_default();
 
+  let is_inline: bool = map_ref.get_with_txn(txn, IS_INLINE).unwrap_or_default();
+
   Some(DatabaseView {
     id,
     database_id,
@@ -419,6 +431,7 @@ pub fn view_from_map_ref<T: ReadTxn>(map_ref: &MapRef, txn: &T) -> Option<Databa
     field_settings,
     created_at,
     modified_at,
+    is_inline,
   })
 }
 

--- a/collab-database/src/views/view_map.rs
+++ b/collab-database/src/views/view_map.rs
@@ -81,7 +81,8 @@ impl DatabaseViews {
         .set_groups(view.group_settings)
         .set_sorts(view.sorts)
         .set_field_orders(view.field_orders)
-        .set_row_orders(view.row_orders);
+        .set_row_orders(view.row_orders)
+        .set_is_inline(view.is_inline);
     });
   }
 

--- a/collab-database/src/workspace_database/manager.rs
+++ b/collab-database/src/workspace_database/manager.rs
@@ -324,14 +324,7 @@ impl WorkspaceDatabaseManager {
     let context = DatabaseContext::new(self.collab_service.clone());
     // Add a new database record.
     let mut linked_views = HashSet::new();
-    linked_views.insert(params.inline_view_id.to_string());
-    linked_views.extend(
-      params
-        .views
-        .iter()
-        .filter(|view| view.view_id != params.inline_view_id)
-        .map(|view| view.view_id.clone()),
-    );
+    linked_views.extend(params.views.iter().map(|view| view.view_id.clone()));
     self
       .body
       .add_database(&params.database_id, linked_views.into_iter().collect());
@@ -414,7 +407,7 @@ impl WorkspaceDatabaseManager {
   ) -> Result<Arc<RwLock<Database>>, DatabaseError> {
     let database_data = self.get_database_data(view_id).await?;
 
-    let create_database_params = CreateDatabaseParams::from_database_data(database_data, None);
+    let create_database_params = CreateDatabaseParams::from_database_data(database_data);
     let database = self.create_database(create_database_params).await?;
     Ok(database)
   }

--- a/collab-database/tests/database_test/cell_test.rs
+++ b/collab-database/tests/database_test/cell_test.rs
@@ -5,7 +5,8 @@ use crate::helper::{TestNumberCell, TestTextCell};
 
 #[tokio::test]
 async fn get_cells_for_field_test() {
-  let database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let database_test = create_database_with_default_data(1, &database_id.to_string()).await;
 
   let cells = database_test.get_cells_for_field("v1", "f1").await;
   assert_eq!(cells.len(), 3);
@@ -19,7 +20,8 @@ async fn get_cells_for_field_test() {
 
 #[tokio::test]
 async fn get_cell_for_field_test() {
-  let database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let cell = database_test
     .get_cell("f1", &database_test.pre_define_row_ids[0])
     .await
@@ -31,7 +33,8 @@ async fn get_cell_for_field_test() {
 
 #[tokio::test]
 async fn update_cell_for_field_test() {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let cells = database_test.get_cells_for_field("v1", "f1").await;
   assert_eq!(cells.len(), 3);
 
@@ -53,7 +56,8 @@ async fn update_cell_for_field_test() {
 
 #[tokio::test]
 async fn update_empty_cell_for_field_test() {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let cells = database_test.get_cells_for_field("v1", "f2").await;
   assert_eq!(cells.len(), 3);
 

--- a/collab-database/tests/database_test/field_setting_test.rs
+++ b/collab-database/tests/database_test/field_setting_test.rs
@@ -10,9 +10,10 @@ use std::collections::HashMap;
 
 #[tokio::test]
 async fn new_field_new_field_setting_test() {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let params = CreateViewParams {
-    database_id: "1".to_string(),
+    database_id: database_id.to_string(),
     view_id: "v2".to_string(),
     field_settings: field_settings_for_default_database(),
     ..Default::default()
@@ -38,9 +39,10 @@ async fn new_field_new_field_setting_test() {
 
 #[tokio::test]
 async fn remove_field_remove_field_setting_test() {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let params = CreateViewParams {
-    database_id: "1".to_string(),
+    database_id: database_id.to_string(),
     view_id: "v2".to_string(),
     field_settings: field_settings_for_default_database(),
     ..Default::default()
@@ -61,7 +63,8 @@ async fn remove_field_remove_field_setting_test() {
 
 #[tokio::test]
 async fn update_field_setting_for_some_fields_test() {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let field_settings = TestFieldSetting {
     width: 100,
     visibility: 1,
@@ -95,7 +98,8 @@ async fn update_field_setting_for_some_fields_test() {
 
 #[tokio::test]
 async fn update_field_setting_test() {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let field_settings = TestFieldSetting {
     width: 100,
     visibility: 1,
@@ -114,7 +118,8 @@ async fn update_field_setting_test() {
 
 #[tokio::test]
 async fn duplicate_view_duplicates_field_settings_test() {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let field_settings = TestFieldSetting {
     width: 100,
     visibility: 1,
@@ -142,10 +147,11 @@ async fn duplicate_view_duplicates_field_settings_test() {
 
 #[tokio::test]
 async fn new_view_requires_deps_field_test() {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let deps_field = Field::new("f4".to_string(), "date".to_string(), 3, false);
   let params = CreateViewParams {
-    database_id: "1".to_string(),
+    database_id: database_id.to_string(),
     view_id: "v2".to_string(),
     layout: DatabaseLayout::Calendar,
     field_settings: field_settings_for_default_database(),

--- a/collab-database/tests/database_test/field_test.rs
+++ b/collab-database/tests/database_test/field_test.rs
@@ -24,7 +24,8 @@ async fn create_single_field_test() {
 
 #[tokio::test]
 async fn duplicate_field_test() {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let original_field = database_test.get_field("f1").unwrap();
   let (index, duplicated_field) = database_test
     .duplicate_field("v1", "f1", |field| format!("{} (copy)", field.name))
@@ -40,7 +41,8 @@ async fn duplicate_field_test() {
 
 #[tokio::test]
 async fn duplicate_field_test2() {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let original_field = database_test.get_field("f3").unwrap();
   let (index, duplicated_field) = database_test
     .duplicate_field("v1", "f3", |field| format!("{} (copy)", field.name))

--- a/collab-database/tests/database_test/filter_test.rs
+++ b/collab-database/tests/database_test/filter_test.rs
@@ -77,7 +77,8 @@ async fn remove_database_view_filter_test() {
 }
 
 async fn create_database_with_two_filters() -> DatabaseTest {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let filter_1 = TestFilter {
     id: "filter_1".to_string(),
     field_id: "f1".to_string(),

--- a/collab-database/tests/database_test/group_test.rs
+++ b/collab-database/tests/database_test/group_test.rs
@@ -26,7 +26,8 @@ async fn create_database_view_with_group_test() {
 
 #[tokio::test]
 async fn create_database_view_with_group_test2() {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let group_setting = TestGroupSetting {
     id: "g1".to_string(),
     field_id: "".to_string(),
@@ -63,7 +64,8 @@ async fn create_database_view_with_group_test2() {
 
 #[tokio::test]
 async fn get_single_database_group_test() {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let group_setting = TestGroupSetting {
     id: "g1".to_string(),
     field_id: "f1".to_string(),
@@ -94,7 +96,8 @@ async fn get_single_database_group_test() {
 
 #[tokio::test]
 async fn get_multiple_database_group_test() {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let group_setting_1 = TestGroupSetting {
     id: "g1".to_string(),
     field_id: "f1".to_string(),
@@ -191,7 +194,8 @@ async fn remove_database_view_group_test() {
 }
 
 async fn create_database_with_two_groups() -> DatabaseTest {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let group_1 = TestGroupSetting {
     id: "g1".to_string(),
     field_id: "f1".to_string(),

--- a/collab-database/tests/database_test/helper.rs
+++ b/collab-database/tests/database_test/helper.rs
@@ -66,7 +66,6 @@ pub fn create_database(uid: i64, database_id: &str) -> DatabaseTest {
   let context = DatabaseContext::new(collab_service);
   let params = CreateDatabaseParams {
     database_id: database_id.to_string(),
-    inline_view_id: "v1".to_string(),
     views: vec![CreateViewParams {
       database_id: database_id.to_string(),
       view_id: "v1".to_string(),
@@ -121,7 +120,6 @@ pub async fn create_database_with_db(
   let context = DatabaseContext::new(collab_service);
   let params = CreateDatabaseParams {
     database_id: database_id.to_string(),
-    inline_view_id: "v1".to_string(),
     views: vec![CreateViewParams {
       database_id: database_id.to_string(),
       view_id: "v1".to_string(),
@@ -216,7 +214,6 @@ impl DatabaseTestBuilder {
     let context = DatabaseContext::new(collab_service);
     let params = CreateDatabaseParams {
       database_id: self.database_id.clone(),
-      inline_view_id: self.view_id.clone(),
       views: vec![CreateViewParams {
         database_id: self.database_id,
         view_id: self.view_id,

--- a/collab-database/tests/database_test/layout_test.rs
+++ b/collab-database/tests/database_test/layout_test.rs
@@ -22,7 +22,8 @@ async fn get_layout_setting_test() {
 
 #[tokio::test]
 async fn create_database_view_with_layout_setting_test() {
-  let database_test = DatabaseTestBuilder::new(1, "1")
+  let database_id = uuid::Uuid::new_v4();
+  let database_test = DatabaseTestBuilder::new(1, &database_id.to_string())
     .with_layout(DatabaseLayout::Calendar)
     .with_field(Field::new(
       "f1".to_string(),
@@ -76,7 +77,8 @@ async fn update_layout_setting_test() {
 }
 
 async fn create_database_with_two_layout_settings() -> DatabaseTest {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let layout_setting_1 = TestCalendarLayoutSetting::new("f1".to_string());
   let layout_setting_2 = TestCalendarLayoutSetting::new("f2".to_string());
 

--- a/collab-database/tests/database_test/restore_test.rs
+++ b/collab-database/tests/database_test/restore_test.rs
@@ -208,7 +208,6 @@ fn expected_json() -> Value {
         }
       }
     ],
-    "inline_view_id": "b44b2906-4508-4532-ad9e-2cf33ceae304",
     "rows": [
       {
         "cells": {

--- a/collab-database/tests/database_test/restore_test.rs
+++ b/collab-database/tests/database_test/restore_test.rs
@@ -10,6 +10,7 @@ use collab::preclude::Collab;
 use collab_database::rows::CreateRowParams;
 use collab_plugins::CollabKVDB;
 use serde_json::{json, Value};
+use uuid::Uuid;
 
 #[tokio::test]
 async fn restore_row_from_disk_test() {
@@ -31,42 +32,43 @@ async fn restore_row_from_disk_test() {
 
 #[tokio::test]
 async fn restore_from_disk_test() {
-  let (db, database_test) = create_database_with_db(1, "1").await;
-  assert_database_eq(database_test).await;
+  let database_id = Uuid::new_v4().to_string();
+  let (db, database_test) = create_database_with_db(1, &database_id).await;
+  assert_database_eq(&database_id, database_test).await;
 
   // Restore from disk
-  let database_test = restore_database_from_db(1, "1", db).await;
-  assert_database_eq(database_test).await;
+  let database_test = restore_database_from_db(1, &database_id, db).await;
+  assert_database_eq(&database_id, database_test).await;
 }
 
 #[tokio::test]
 async fn restore_from_disk_with_different_database_id_test() {
-  let (db, _) = create_database_with_db(1, "1").await;
-  let database_test = restore_database_from_db(1, "1", db).await;
+  let database_id = Uuid::new_v4().to_string();
+  let (db, _) = create_database_with_db(1, &database_id).await;
+  let database_test = restore_database_from_db(1, &database_id, db).await;
 
-  assert_database_eq(database_test).await;
+  assert_database_eq(&database_id, database_test).await;
 }
 
 #[tokio::test]
 async fn restore_from_disk_with_different_uid_test() {
-  let (db, _) = create_database_with_db(1, "1").await;
-  let database_test = restore_database_from_db(1, "1", db).await;
+  let database_id = Uuid::new_v4().to_string();
+  let (db, _) = create_database_with_db(1, &database_id).await;
+  let database_test = restore_database_from_db(1, &database_id, db).await;
 
-  assert_database_eq(database_test).await;
+  assert_database_eq(&database_id, database_test).await;
 }
 
-async fn assert_database_eq(database_test: DatabaseTest) {
+async fn assert_database_eq(database_id: &str, database_test: DatabaseTest) {
   let expected = json!( {
     "fields": [],
-    "inline_view_id": "v1",
     "rows": [],
     "views": [
       {
-        "database_id": "1",
+        "database_id": database_id,
         "field_orders": [],
         "filters": [],
         "group_settings": [],
-        "id": "v1",
         "layout": 0,
         "layout_settings": {},
         "row_orders": [],

--- a/collab-database/tests/database_test/row_test.rs
+++ b/collab-database/tests/database_test/row_test.rs
@@ -66,7 +66,8 @@ async fn delete_row_shared_by_two_view_test() {
 
 #[tokio::test]
 async fn move_row_in_view_test() {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let rows = database_test.get_rows_for_view("v1").await;
   let first_row_id = database_test.pre_define_row_ids[0].clone();
   let second_row_id = database_test.pre_define_row_ids[1].clone();
@@ -97,7 +98,8 @@ async fn move_row_in_view_test() {
 
 #[tokio::test]
 async fn move_row_in_view_test2() {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let rows = database_test.get_rows_for_view("v1").await;
   let first_row_id = database_test.pre_define_row_ids[0].clone();
   let second_row_id = database_test.pre_define_row_ids[1].clone();
@@ -119,9 +121,10 @@ async fn move_row_in_view_test2() {
 
 #[tokio::test]
 async fn move_row_in_views_test() {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let params = CreateViewParams {
-    database_id: "1".to_string(),
+    database_id: database_id.to_string(),
     view_id: "v2".to_string(),
     ..Default::default()
   };
@@ -229,7 +232,8 @@ async fn insert_row_at_last_in_views_test() {
 
 #[tokio::test]
 async fn duplicate_row_test() {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let rows = database_test.get_rows_for_view("v1").await;
   assert_eq!(rows.len(), 3);
   let first_row_id = database_test.pre_define_row_ids[0].clone();
@@ -254,7 +258,8 @@ async fn duplicate_row_test() {
 
 #[tokio::test]
 async fn duplicate_last_row_test() {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let rows = database_test.get_rows_for_view("v1").await;
   assert_eq!(rows.len(), 3);
 

--- a/collab-database/tests/database_test/sort_test.rs
+++ b/collab-database/tests/database_test/sort_test.rs
@@ -89,7 +89,8 @@ async fn reorder_database_view_sort_test() {
 }
 
 async fn create_database_with_two_sorts() -> DatabaseTest {
-  let mut database_test = create_database_with_default_data(1, "1").await;
+  let database_id = uuid::Uuid::new_v4();
+  let mut database_test = create_database_with_default_data(1, &database_id.to_string()).await;
   let sort_1 = TestSort {
     id: "s1".to_string(),
     field_id: "f1".to_string(),
@@ -104,7 +105,7 @@ async fn create_database_with_two_sorts() -> DatabaseTest {
   };
 
   let params = CreateViewParams {
-    database_id: "1".to_string(),
+    database_id: database_id.to_string(),
     view_id: "v1".to_string(),
     sorts: vec![sort_1.into(), sort_2.into()],
     layout: DatabaseLayout::Grid,

--- a/collab-database/tests/database_test/type_option_test.rs
+++ b/collab-database/tests/database_test/type_option_test.rs
@@ -1,12 +1,12 @@
-use collab::util::AnyMapExt;
-use collab_database::fields::{Field, TypeOptionDataBuilder, TypeOptions};
-use collab_database::views::OrderObjectPosition;
-use std::ops::DerefMut;
-
 use crate::database_test::helper::{
   create_database, default_field_settings_by_layout, DatabaseTest,
 };
 use crate::helper::{TestCheckboxTypeOption, TestDateFormat, TestDateTypeOption, TestTimeFormat};
+use collab::util::AnyMapExt;
+use collab_database::fields::{Field, TypeOptionDataBuilder, TypeOptions};
+use collab_database::views::OrderObjectPosition;
+use std::ops::DerefMut;
+use uuid::Uuid;
 
 #[tokio::test]
 async fn insert_checkbox_type_option_data_test() {
@@ -149,7 +149,8 @@ async fn insert_multi_type_options_test() {
 }
 
 fn user_database_with_default_field() -> DatabaseTest {
-  let mut test = create_database(1, "1");
+  let database_id = Uuid::new_v4().to_string();
+  let mut test = create_database(1, &database_id);
 
   let field = Field {
     id: "f1".to_string(),

--- a/collab-database/tests/database_test/view_observe_test.rs
+++ b/collab-database/tests/database_test/view_observe_test.rs
@@ -258,15 +258,18 @@ async fn observer_create_delete_row_test() {
       insert_row_orders,
       delete_row_indexes,
     } => {
-      assert!(is_local_change);
-      assert_eq!(delete_row_indexes.len(), 0);
-      assert_eq!(database_view_id, &"v1".to_string());
-      for (row_order, index) in insert_row_orders {
-        let pos = created_row.iter().position(|x| x == &row_order.id).unwrap() as u32;
-        assert_eq!(&pos, index);
-        received_rows.push(row_order.id.clone());
+      if database_view_id == "v1" {
+        assert!(is_local_change);
+        assert_eq!(delete_row_indexes.len(), 0);
+        for (row_order, index) in insert_row_orders {
+          let pos = created_row.iter().position(|x| x == &row_order.id).unwrap() as u32;
+          assert_eq!(&pos, index);
+          received_rows.push(row_order.id.clone());
+        }
+        created_row == received_rows
+      } else {
+        false
       }
-      created_row == received_rows
     },
     _ => false,
   })
@@ -289,16 +292,18 @@ async fn observer_create_delete_row_test() {
       insert_row_orders,
       delete_row_indexes,
     } => {
-      assert!(is_local_change);
-      assert_eq!(database_view_id, &"v1".to_string());
+      if database_view_id == "v1" {
+        assert!(is_local_change);
+        assert_eq!(delete_row_indexes.len(), 1);
+        assert_eq!(delete_row_indexes[0], 0);
 
-      assert_eq!(delete_row_indexes.len(), 1);
-      assert_eq!(delete_row_indexes[0], 0);
-
-      assert_eq!(insert_row_orders.len(), 1);
-      assert_eq!(insert_row_orders[0].0.id, cloned_created_row[0]);
-      assert_eq!(insert_row_orders[0].1, 3);
-      true
+        assert_eq!(insert_row_orders.len(), 1);
+        assert_eq!(insert_row_orders[0].0.id, cloned_created_row[0]);
+        assert_eq!(insert_row_orders[0].1, 3);
+        true
+      } else {
+        false
+      }
     },
     _ => false,
   })

--- a/collab-database/tests/user_test/database_test.rs
+++ b/collab-database/tests/user_test/database_test.rs
@@ -1,23 +1,23 @@
-use collab_database::database::gen_database_view_id;
-use collab_database::entity::{CreateDatabaseParams, CreateViewParams, FileUploadType};
-use collab_database::rows::{CoverType, CreateRowParams, Row, RowCover};
-use futures::StreamExt;
-
 use crate::user_test::helper::{
   make_default_grid, random_uid, user_database_test_with_db, user_database_test_with_default_data,
   workspace_database_test,
 };
+use collab_database::database::gen_database_view_id;
+use collab_database::entity::{CreateDatabaseParams, CreateViewParams, FileUploadType};
+use collab_database::rows::{CoverType, CreateRowParams, Row, RowCover};
+use futures::StreamExt;
+use uuid::Uuid;
 
 #[tokio::test]
 async fn create_database_test() {
   let uid = random_uid();
+  let database_id = Uuid::new_v4();
   let mut test = workspace_database_test(uid).await;
   let database = test
     .create_database(CreateDatabaseParams {
-      database_id: "d1".to_string(),
-      inline_view_id: "v1".to_string(),
+      database_id: database_id.to_string(),
       views: vec![CreateViewParams {
-        database_id: "d1".to_string(),
+        database_id: database_id.to_string(),
         view_id: "v1".to_string(),
         ..Default::default()
       }],
@@ -35,12 +35,12 @@ async fn create_database_test() {
 async fn create_multiple_database_test() {
   let uid = random_uid();
   let mut test = workspace_database_test(uid).await;
+  let database_id_1 = Uuid::new_v4();
   test
     .create_database(CreateDatabaseParams {
-      database_id: "d1".to_string(),
-      inline_view_id: "v1".to_string(),
+      database_id: database_id_1.to_string(),
       views: vec![CreateViewParams {
-        database_id: "d1".to_string(),
+        database_id: database_id_1.to_string(),
         view_id: "v1".to_string(),
         ..Default::default()
       }],
@@ -48,12 +48,13 @@ async fn create_multiple_database_test() {
     })
     .await
     .unwrap();
+
+  let database_id_2 = Uuid::new_v4();
   test
     .create_database(CreateDatabaseParams {
-      database_id: "d2".to_string(),
-      inline_view_id: "v2".to_string(),
+      database_id: database_id_2.to_string(),
       views: vec![CreateViewParams {
-        database_id: "d2".to_string(),
+        database_id: database_id_2.to_string(),
         view_id: "v2".to_string(),
         ..Default::default()
       }],
@@ -63,20 +64,20 @@ async fn create_multiple_database_test() {
     .unwrap();
   let all_databases = test.get_all_database_meta();
   assert_eq!(all_databases.len(), 2);
-  assert_eq!(all_databases[0].database_id, "d1");
-  assert_eq!(all_databases[1].database_id, "d2");
+  assert_eq!(all_databases[0].database_id, database_id_1.to_string());
+  assert_eq!(all_databases[1].database_id, database_id_2.to_string());
 }
 
 #[tokio::test]
 async fn delete_database_test() {
   let uid = random_uid();
+  let database_id_1 = Uuid::new_v4();
   let mut test = workspace_database_test(uid).await;
   test
     .create_database(CreateDatabaseParams {
-      database_id: "d1".to_string(),
-      inline_view_id: "v1".to_string(),
+      database_id: database_id_1.to_string(),
       views: vec![CreateViewParams {
-        database_id: "d1".to_string(),
+        database_id: database_id_1.to_string(),
         view_id: "v1".to_string(),
         ..Default::default()
       }],
@@ -84,12 +85,12 @@ async fn delete_database_test() {
     })
     .await
     .unwrap();
+  let database_id_2 = Uuid::new_v4();
   test
     .create_database(CreateDatabaseParams {
-      database_id: "d2".to_string(),
-      inline_view_id: "v2".to_string(),
+      database_id: database_id_2.to_string(),
       views: vec![CreateViewParams {
-        database_id: "d2".to_string(),
+        database_id: database_id_2.to_string(),
         view_id: "v2".to_string(),
         ..Default::default()
       }],
@@ -97,23 +98,22 @@ async fn delete_database_test() {
     })
     .await
     .unwrap();
-  test.delete_database("d1");
+  test.delete_database(&database_id_1.to_string());
 
   let all_databases = test.get_all_database_meta();
-  assert_eq!(all_databases[0].database_id, "d2");
+  assert_eq!(all_databases[0].database_id, database_id_2.to_string());
 }
 
 #[tokio::test]
 async fn duplicate_database_inline_view_test() {
   let uid = random_uid();
   let mut test = workspace_database_test(uid).await;
-  let database_id = "d1".to_string();
+  let database_id = Uuid::new_v4();
   let database = test
     .create_database(CreateDatabaseParams {
-      database_id: database_id.clone(),
-      inline_view_id: "v1".to_string(),
+      database_id: database_id.to_string(),
       views: vec![CreateViewParams {
-        database_id: "d1".to_string(),
+        database_id: database_id.to_string(),
         view_id: "v1".to_string(),
         ..Default::default()
       }],
@@ -125,7 +125,7 @@ async fn duplicate_database_inline_view_test() {
   let duplicated_database = test.duplicate_database("v1").await.unwrap();
   let mut db = duplicated_database.write().await;
   let duplicated_view_id = db.get_inline_view_id();
-  db.create_row(CreateRowParams::new(1, database_id.clone()))
+  db.create_row(CreateRowParams::new(1, database_id.to_string()))
     .await
     .unwrap();
 
@@ -153,13 +153,12 @@ async fn duplicate_database_view_test() {
   let mut test = workspace_database_test(random_uid()).await;
 
   // create the database with inline view
-  let database_id = "d1".to_string();
+  let database_id = Uuid::new_v4();
   let database = test
     .create_database(CreateDatabaseParams {
-      database_id: database_id.clone(),
-      inline_view_id: "v1".to_string(),
+      database_id: database_id.to_string(),
       views: vec![CreateViewParams {
-        database_id: "d1".to_string(),
+        database_id: database_id.to_string(),
         view_id: "v1".to_string(),
         ..Default::default()
       }],
@@ -170,7 +169,7 @@ async fn duplicate_database_view_test() {
 
   test
     .create_database_linked_view(CreateViewParams {
-      database_id: "d1".to_string(),
+      database_id: database_id.to_string(),
       view_id: "v2".to_string(),
       ..Default::default()
     })
@@ -180,7 +179,7 @@ async fn duplicate_database_view_test() {
   // Duplicate the linked view.
   let mut db = database.write().await;
   let duplicated_view = db.duplicate_linked_view("v2").unwrap();
-  db.create_row(CreateRowParams::new(1, database_id.clone()))
+  db.create_row(CreateRowParams::new(1, database_id.to_string()))
     .await
     .unwrap();
 
@@ -198,12 +197,12 @@ async fn duplicate_database_view_test() {
 #[tokio::test]
 async fn delete_database_linked_view_test() {
   let mut test = workspace_database_test(random_uid()).await;
+  let database_id = Uuid::new_v4();
   let database = test
     .create_database(CreateDatabaseParams {
-      database_id: "d1".to_string(),
-      inline_view_id: "v1".to_string(),
+      database_id: database_id.to_string(),
       views: vec![CreateViewParams {
-        database_id: "d1".to_string(),
+        database_id: database_id.to_string(),
         view_id: "v1".to_string(),
         ..Default::default()
       }],
@@ -214,7 +213,7 @@ async fn delete_database_linked_view_test() {
 
   let mut db = database.write().await;
   db.create_linked_view(CreateViewParams {
-    database_id: "d1".to_string(),
+    database_id: database_id.to_string(),
     view_id: "v2".to_string(),
     ..Default::default()
   })
@@ -237,12 +236,12 @@ async fn delete_database_linked_view_test() {
 #[tokio::test]
 async fn delete_database_inline_view_test() {
   let mut test = workspace_database_test(random_uid()).await;
+  let database_id = Uuid::new_v4();
   let database = test
     .create_database(CreateDatabaseParams {
-      database_id: "d1".to_string(),
-      inline_view_id: "v1".to_string(),
+      database_id: database_id.to_string(),
       views: vec![CreateViewParams {
-        database_id: "d1".to_string(),
+        database_id: database_id.to_string(),
         view_id: "v1".to_string(),
         ..Default::default()
       }],
@@ -254,22 +253,21 @@ async fn delete_database_inline_view_test() {
   let mut db = database.write().await;
   for i in 2..5 {
     db.create_linked_view(CreateViewParams {
-      database_id: "d1".to_string(),
+      database_id: database_id.to_string(),
       view_id: format!("v{}", i),
       ..Default::default()
     })
     .unwrap();
   }
 
-  // there should be 4 views: inline-view v1 and created linked-views v2, v3 and v4.
+  // there should be 4 views: v1, v2, v3 and v4.
   let views = db.get_all_views();
   assert_eq!(views.len(), 4);
   drop(db);
 
-  // After deleting the inline view, all linked views will be removed
-  test.delete_view("d1", "v1").await;
+  test.delete_view(&database_id.to_string(), "v1").await;
   let views = database.read().await.get_all_views();
-  assert_eq!(views.len(), 0);
+  assert_eq!(views.len(), 3);
 }
 
 #[tokio::test]
@@ -331,12 +329,12 @@ async fn duplicate_database_data_test() {
 #[tokio::test]
 async fn get_database_by_view_id_test() {
   let mut test = workspace_database_test(random_uid()).await;
+  let database_id = Uuid::new_v4();
   let _database = test
     .create_database(CreateDatabaseParams {
-      database_id: "d1".to_string(),
-      inline_view_id: "v1".to_string(),
+      database_id: database_id.to_string(),
       views: vec![CreateViewParams {
-        database_id: "d1".to_string(),
+        database_id: database_id.to_string(),
         view_id: "v1".to_string(),
         ..Default::default()
       }],
@@ -347,7 +345,7 @@ async fn get_database_by_view_id_test() {
 
   test
     .create_database_linked_view(CreateViewParams {
-      database_id: "d1".to_string(),
+      database_id: database_id.to_string(),
       view_id: "v2".to_string(),
       ..Default::default()
     })

--- a/collab-database/tests/user_test/helper.rs
+++ b/collab-database/tests/user_test/helper.rs
@@ -34,6 +34,7 @@ use collab_plugins::local_storage::rocksdb::util::KVDBCollabPersistenceImpl;
 use collab_plugins::CollabKVDB;
 use rand::Rng;
 use tempfile::TempDir;
+use uuid::Uuid;
 
 pub struct WorkspaceDatabaseTest {
   #[allow(dead_code)]
@@ -297,8 +298,9 @@ pub async fn user_database_test_with_default_data(uid: i64) -> WorkspaceDatabase
   let db = Arc::new(CollabKVDB::open(path).unwrap());
   let mut w_database = user_database_test_with_db(uid, db).await;
 
+  let database_id = Uuid::new_v4().to_string();
   w_database
-    .create_database(create_database_params("d1"))
+    .create_database(create_database_params(database_id.as_str()))
     .await
     .unwrap();
 
@@ -327,7 +329,6 @@ fn create_database_params(database_id: &str) -> CreateDatabaseParams {
 
   CreateDatabaseParams {
     database_id: database_id.to_string(),
-    inline_view_id: "v1".to_string(),
     views: vec![CreateViewParams {
       database_id: database_id.to_string(),
       view_id: "v1".to_string(),
@@ -368,7 +369,6 @@ pub fn make_default_grid(view_id: &str, name: &str) -> CreateDatabaseParams {
 
   CreateDatabaseParams {
     database_id: database_id.clone(),
-    inline_view_id: view_id.to_string(),
     views: vec![CreateViewParams {
       database_id: database_id.clone(),
       view_id: view_id.to_string(),


### PR DESCRIPTION
Make the inline database view private. When creating a new database, it should now include two views: one for the inline view and one for the display view