### PR TITLE
fix: default hide file names to true

### DIFF
--- a/collab-database/src/fields/type_option/media_type_option.rs
+++ b/collab-database/src/fields/type_option/media_type_option.rs
@@ -11,10 +11,17 @@ use std::path::Path;
 use std::sync::Arc;
 use yrs::Any;
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MediaTypeOption {
-  #[serde(default)]
   pub hide_file_names: bool,
+}
+
+impl Default for MediaTypeOption {
+  fn default() -> Self {
+    Self {
+      hide_file_names: true,
+    }
+  }
 }
 
 impl StringifyTypeOption for MediaTypeOption {


### PR DESCRIPTION
I just implement the default, I find it cleaner as opposed to this:
```rust
#[derive(Debug, Clone, Serialize, Deserialize)]
pub struct MediaTypeOption {
  #[serde(default = 'make_true')]
  pub hide_file_names: bool,
}

fn make_true() -> bool {
    true
}
```