### PR TITLE
fix: awareness state observer should emit state for all users

### DIFF
--- a/collab-document/src/document.rs
+++ b/collab-document/src/document.rs
@@ -363,8 +363,8 @@ impl Document {
 
   /// Set the local state of the awareness.
   /// It will override the previous state.
-  pub fn set_awareness_local_state(&mut self, state: DocumentAwarenessState) {
-    if let Err(e) = self.collab.get_mut_awareness().set_local_state(state) {
+  pub fn set_awareness_local_state(&self, state: DocumentAwarenessState) {
+    if let Err(e) = self.collab.get_awareness().set_local_state(state) {
       tracing::error!("Failed to serialize DocumentAwarenessState, state: {}", e);
     }
   }
@@ -386,8 +386,8 @@ impl Document {
     K: Into<Origin>,
     F: Fn(HashMap<ClientID, DocumentAwarenessState>) + Send + Sync + 'static,
   {
-    self.collab.get_awareness().on_update_with(key, move |awareness, e, _| {
-      if let Ok(full_update) = awareness.update_with_clients(e.all_changes()) {
+    self.collab.get_awareness().on_update_with(key, move |awareness, _, _| {
+      if let Ok(full_update) = awareness.update() {
         let result: HashMap<_, _> = full_update.clients.iter().filter_map(|(&client_id, entry)| {
           match serde_json::from_str::<Option<DocumentAwarenessState>>(&entry.json) {
             Ok(state) => state.map(|state| (client_id, state)),

--- a/collab-document/src/document.rs
+++ b/collab-document/src/document.rs
@@ -387,6 +387,7 @@ impl Document {
     F: Fn(HashMap<ClientID, DocumentAwarenessState>) + Send + Sync + 'static,
   {
     self.collab.get_awareness().on_update_with(key, move |awareness, _, _| {
+      // emit new awareness state for all known clients
       if let Ok(full_update) = awareness.update() {
         let result: HashMap<_, _> = full_update.clients.iter().filter_map(|(&client_id, entry)| {
           match serde_json::from_str::<Option<DocumentAwarenessState>>(&entry.json) {

--- a/collab-document/tests/document/awareness_test.rs
+++ b/collab-document/tests/document/awareness_test.rs
@@ -5,10 +5,11 @@ use collab::preclude::block::ClientID;
 use collab::preclude::updates::decoder::{Decode, Decoder};
 use collab_document::document_awareness::{DocumentAwarenessState, DocumentAwarenessUser};
 
+use arc_swap::ArcSwapOption;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
-use std::sync::mpsc;
+use std::sync::{mpsc, Arc};
 use yrs::sync::awareness::AwarenessUpdateEntry;
 use yrs::updates::encoder::{Encode, Encoder};
 
@@ -145,6 +146,78 @@ fn document_awareness_serde_test2() {
   assert_eq!(
     document_state_from_old_version_awareness.version,
     document_state.version
+  );
+}
+
+#[test]
+fn document_awareness_incoming_update() {
+  let mut d1 = DocumentTest::new(2, "1");
+  let mut d2 = DocumentTest::new(2, "1");
+
+  // 1. subscribe to awareness state changes on both ends
+  let d1_awareness_state = Arc::new(ArcSwapOption::default());
+  let awareness_state = d1_awareness_state.clone();
+  d1.document
+    .subscribe_awareness_state("test", move |a| awareness_state.store(Some(a.into())));
+
+  let d2_awareness_state = Arc::new(ArcSwapOption::default());
+  let awareness_state = d2_awareness_state.clone();
+  d2.document
+    .subscribe_awareness_state("test", move |a| awareness_state.store(Some(a.into())));
+
+  // 2. subscribe to awareness changes in the same way as `observe_awareness` from collab.rs
+  let d1 = Arc::new(d1);
+  let d2 = Arc::new(d2);
+  let other = d2.clone();
+  d1.get_awareness()
+    .on_update_with("sync", move |awareness, e, _| {
+      // we only send actual changes not entire awareness state
+      if let Ok(update) = awareness.update_with_clients(e.all_changes()) {
+        other.get_awareness().apply_update(update).unwrap();
+      }
+    });
+  let other = d1.clone();
+  d2.get_awareness()
+    .on_update_with("sync", move |awareness, e, _| {
+      // we only send actual changes not entire awareness state
+      if let Ok(update) = awareness.update_with_clients(e.all_changes()) {
+        other.get_awareness().apply_update(update).unwrap();
+      }
+    });
+
+  // 3. set new awareness state on both ends
+  println!("setting D1");
+  d1.set_awareness_local_state(DocumentAwarenessState {
+    version: 1,
+    user: DocumentAwarenessUser {
+      uid: 1,
+      device_id: "device_1".to_string(),
+    },
+    selection: None,
+    metadata: Some("meta1".into()),
+    timestamp: 1111,
+  });
+  println!("setting D2");
+  d2.set_awareness_local_state(DocumentAwarenessState {
+    version: 1,
+    user: DocumentAwarenessUser {
+      uid: 2,
+      device_id: "device_2".to_string(),
+    },
+    selection: None,
+    metadata: Some("meta2".into()),
+    timestamp: 2222,
+  });
+
+  // 4. compare received states
+  let state1 = d1_awareness_state.swap(None).unwrap();
+  let state2 = d2_awareness_state.swap(None).unwrap();
+
+  assert_eq!(state1, state2, "both clients should have equal state");
+  assert_eq!(
+    state1.len(),
+    2,
+    "subscribe_awareness_state should return full state"
   );
 }
 

--- a/collab-document/tests/document/awareness_test.rs
+++ b/collab-document/tests/document/awareness_test.rs
@@ -186,7 +186,6 @@ fn document_awareness_incoming_update() {
     });
 
   // 3. set new awareness state on both ends
-  println!("setting D1");
   d1.set_awareness_local_state(DocumentAwarenessState {
     version: 1,
     user: DocumentAwarenessUser {
@@ -197,7 +196,6 @@ fn document_awareness_incoming_update() {
     metadata: Some("meta1".into()),
     timestamp: 1111,
   });
-  println!("setting D2");
   d2.set_awareness_local_state(DocumentAwarenessState {
     version: 1,
     user: DocumentAwarenessUser {


### PR DESCRIPTION
One of the bugs that we received mentioned that the list of active collaborators only contains the latest updated user instead of all of them. This PR fixes it and adds the test to confirm the correct behavior.