### PR TITLE
chore: refactor space info

### DIFF
--- a/collab-folder/src/hierarchy_builder.rs
+++ b/collab-folder/src/hierarchy_builder.rs
@@ -270,8 +270,12 @@ impl ViewExtraBuilder {
   pub fn with_space_info(mut self, space_info: SpaceInfo) -> Self {
     self.0[SPACE_IS_SPACE_KEY] = json!(space_info.is_space);
     self.0[SPACE_PERMISSION_KEY] = json!(space_info.space_permission as u8);
-    self.0[SPACE_ICON_KEY] = json!(space_info.space_icon);
-    self.0[SPACE_ICON_COLOR_KEY] = json!(space_info.space_icon_color);
+    if let Some(icon) = space_info.space_icon {
+      self.0[SPACE_ICON_KEY] = json!(icon);
+    }
+    if let Some(icon_color) = space_info.space_icon_color {
+      self.0[SPACE_ICON_COLOR_KEY] = json!(icon_color);
+    }
     self
   }
 

--- a/collab-folder/src/hierarchy_builder.rs
+++ b/collab-folder/src/hierarchy_builder.rs
@@ -1,7 +1,7 @@
 use crate::space_info::SpacePermission;
 use crate::{
-  timestamp, IconType, RepeatedViewIdentifier, View, ViewIcon, ViewIdentifier, ViewLayout,
-  SPACE_CREATED_AT_KEY, SPACE_ICON_COLOR_KEY, SPACE_ICON_KEY, SPACE_IS_SPACE_KEY,
+  timestamp, IconType, RepeatedViewIdentifier, SpaceInfo, View, ViewIcon, ViewIdentifier,
+  ViewLayout, SPACE_CREATED_AT_KEY, SPACE_ICON_COLOR_KEY, SPACE_ICON_KEY, SPACE_IS_SPACE_KEY,
   SPACE_PERMISSION_KEY,
 };
 
@@ -248,18 +248,30 @@ impl ViewExtraBuilder {
     self
   }
 
-  pub fn with_space_icon_key(mut self, icon_key: &str) -> Self {
-    self.0[SPACE_ICON_KEY] = json!(icon_key);
+  pub fn with_space_icon(mut self, icon: Option<&str>) -> Self {
+    if let Some(icon) = icon {
+      self.0[SPACE_ICON_KEY] = json!(icon);
+    }
     self
   }
 
-  pub fn with_space_icon_color_key(mut self, icon_color_key: &str) -> Self {
-    self.0[SPACE_ICON_COLOR_KEY] = json!(icon_color_key);
+  pub fn with_space_icon_color(mut self, icon_color: Option<&str>) -> Self {
+    if let Some(icon_color) = icon_color {
+      self.0[SPACE_ICON_COLOR_KEY] = json!(icon_color);
+    }
     self
   }
 
   pub fn with_space_permission(mut self, permission: SpacePermission) -> Self {
     self.0[SPACE_PERMISSION_KEY] = json!(permission as u8);
+    self
+  }
+
+  pub fn with_space_info(mut self, space_info: SpaceInfo) -> Self {
+    self.0[SPACE_IS_SPACE_KEY] = json!(space_info.is_space);
+    self.0[SPACE_PERMISSION_KEY] = json!(space_info.space_permission as u8);
+    self.0[SPACE_ICON_KEY] = json!(space_info.space_icon);
+    self.0[SPACE_ICON_COLOR_KEY] = json!(space_info.space_icon_color);
     self
   }
 

--- a/collab-folder/src/hierarchy_builder.rs
+++ b/collab-folder/src/hierarchy_builder.rs
@@ -1,5 +1,8 @@
+use crate::space_info::SpacePermission;
 use crate::{
   timestamp, IconType, RepeatedViewIdentifier, View, ViewIcon, ViewIdentifier, ViewLayout,
+  SPACE_CREATED_AT_KEY, SPACE_ICON_COLOR_KEY, SPACE_ICON_KEY, SPACE_IS_SPACE_KEY,
+  SPACE_PERMISSION_KEY,
 };
 
 use serde_json::json;
@@ -236,23 +239,33 @@ impl ViewExtraBuilder {
   pub fn new() -> Self {
     Self(json!({}))
   }
-  pub fn is_space(mut self, is_space: bool, permission: SpacePermission) -> Self {
-    self.0["is_space"] = json!(is_space);
-    self.0["space_permission"] = json!(permission as u8);
-    self.0["space_created_at"] = json!(timestamp());
+
+  pub fn is_space(mut self, is_space: bool) -> Self {
+    self.0[SPACE_IS_SPACE_KEY] = json!(is_space);
+    if is_space {
+      self.0[SPACE_CREATED_AT_KEY] = json!(timestamp());
+    }
+    self
+  }
+
+  pub fn with_space_icon_key(mut self, icon_key: &str) -> Self {
+    self.0[SPACE_ICON_KEY] = json!(icon_key);
+    self
+  }
+
+  pub fn with_space_icon_color_key(mut self, icon_color_key: &str) -> Self {
+    self.0[SPACE_ICON_COLOR_KEY] = json!(icon_color_key);
+    self
+  }
+
+  pub fn with_space_permission(mut self, permission: SpacePermission) -> Self {
+    self.0[SPACE_PERMISSION_KEY] = json!(permission as u8);
     self
   }
 
   pub fn build(self) -> serde_json::Value {
     self.0
   }
-}
-
-#[derive(Debug, Clone, serde_repr::Serialize_repr, serde_repr::Deserialize_repr)]
-#[repr(u8)]
-pub enum SpacePermission {
-  PublicToAll = 0,
-  Private = 1,
 }
 
 #[derive(Debug, Clone)]

--- a/collab-folder/src/lib.rs
+++ b/collab-folder/src/lib.rs
@@ -5,6 +5,7 @@ pub use folder_observe::*;
 pub use relation::*;
 pub use section::*;
 // pub use trash::*;
+pub use space_info::*;
 pub use view::*;
 pub use workspace::*;
 
@@ -23,3 +24,4 @@ pub mod folder_diff;
 mod folder_migration;
 mod folder_observe;
 pub mod hierarchy_builder;
+pub mod space_info;

--- a/collab-folder/src/space_info.rs
+++ b/collab-folder/src/space_info.rs
@@ -1,0 +1,47 @@
+use serde::{Deserialize, Serialize};
+
+pub const SPACE_IS_SPACE_KEY: &str = "is_space";
+pub const SPACE_PERMISSION_KEY: &str = "space_permission";
+pub const SPACE_ICON_KEY: &str = "space_icon";
+pub const SPACE_ICON_COLOR_KEY: &str = "space_icon_color";
+pub const SPACE_CREATED_AT_KEY: &str = "space_created_at";
+
+/// Represents the space info of a view
+///
+/// Two view types are supported:
+///
+/// - Space view: A view associated with a space info. Parent view that can contain normal views.
+///   Child views inherit the space's permissions.
+///
+/// - Normal view: Cannot contain space views and has no direct permission controls.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SpaceInfo {
+  /// Whether the view is a space view.
+  pub is_space: bool,
+
+  /// The permission of the space view.
+  ///
+  /// If the space_permission is none, the space view will use the SpacePermission::PublicToAll.
+  pub space_permission: Option<SpacePermission>,
+
+  /// The created time of the space view.
+  pub created_at: i64,
+
+  /// The space icon key.
+  ///
+  /// If the space_icon_key is none, the space view will use the default icon.
+  pub space_icon_key: Option<String>,
+
+  /// The space icon color key.
+  ///
+  /// If the space_icon_color_key is none, the space view will use the default icon color.
+  /// The value should be a valid hex color code: 0xFFA34AFD
+  pub space_icon_color_key: Option<String>,
+}
+
+#[derive(Debug, Clone, serde_repr::Serialize_repr, serde_repr::Deserialize_repr)]
+#[repr(u8)]
+pub enum SpacePermission {
+  PublicToAll = 0,
+  Private = 1,
+}

--- a/collab-folder/src/space_info.rs
+++ b/collab-folder/src/space_info.rs
@@ -27,7 +27,7 @@ pub struct SpaceInfo {
   pub space_permission: SpacePermission,
 
   /// The created time of the space view.
-  pub created_at: i64,
+  pub space_created_at: i64,
 
   /// The space icon.
   ///
@@ -50,7 +50,7 @@ impl Default for SpaceInfo {
     Self {
       is_space: true,
       space_permission: SpacePermission::PublicToAll,
-      created_at: timestamp(),
+      space_created_at: timestamp(),
       space_icon: None,
       space_icon_color: None,
     }

--- a/collab-folder/src/space_info.rs
+++ b/collab-folder/src/space_info.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::timestamp;
+
 pub const SPACE_IS_SPACE_KEY: &str = "is_space";
 pub const SPACE_PERMISSION_KEY: &str = "space_permission";
 pub const SPACE_ICON_KEY: &str = "space_icon";
@@ -22,21 +24,37 @@ pub struct SpaceInfo {
   /// The permission of the space view.
   ///
   /// If the space_permission is none, the space view will use the SpacePermission::PublicToAll.
-  pub space_permission: Option<SpacePermission>,
+  pub space_permission: SpacePermission,
 
   /// The created time of the space view.
   pub created_at: i64,
 
-  /// The space icon key.
+  /// The space icon.
   ///
-  /// If the space_icon_key is none, the space view will use the default icon.
-  pub space_icon_key: Option<String>,
+  /// If the space_icon is none, the space view will use the default icon.
+  pub space_icon: Option<String>,
 
-  /// The space icon color key.
+  /// The space icon color.
   ///
-  /// If the space_icon_color_key is none, the space view will use the default icon color.
+  /// If the space_icon_color is none, the space view will use the default icon color.
   /// The value should be a valid hex color code: 0xFFA34AFD
-  pub space_icon_color_key: Option<String>,
+  pub space_icon_color: Option<String>,
+}
+
+impl Default for SpaceInfo {
+  /// Default space info is a public space
+  ///
+  /// The permission is public to all
+  /// The created time is the current timestamp
+  fn default() -> Self {
+    Self {
+      is_space: true,
+      space_permission: SpacePermission::PublicToAll,
+      created_at: timestamp(),
+      space_icon: None,
+      space_icon_color: None,
+    }
+  }
 }
 
 #[derive(Debug, Clone, serde_repr::Serialize_repr, serde_repr::Deserialize_repr)]

--- a/collab-folder/src/view.rs
+++ b/collab-folder/src/view.rs
@@ -12,8 +12,9 @@ use serde_repr::*;
 use tracing::{instrument, trace};
 
 use crate::folder_observe::ViewChangeSender;
-use crate::hierarchy_builder::SpacePermission;
+
 use crate::section::{Section, SectionItem, SectionMap};
+use crate::space_info::SpaceInfo;
 use crate::{impl_any_update, impl_i64_update, impl_option_i64_update, impl_str_update, UserId};
 use crate::{subscribe_view_change, ParentChildRelations, RepeatedViewIdentifier, ViewIdentifier};
 
@@ -736,12 +737,6 @@ impl View {
     let extra = self.extra.as_ref()?;
     serde_json::from_str::<SpaceInfo>(extra).ok()
   }
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct SpaceInfo {
-  pub is_space: bool,
-  pub space_permission: SpacePermission,
 }
 
 /// Represents a the index of a view.

--- a/collab-folder/tests/folder_test/main.rs
+++ b/collab-folder/tests/folder_test/main.rs
@@ -4,6 +4,7 @@ mod favorite_test;
 mod load_disk;
 mod recent_views_test;
 mod serde_test;
+mod space_info_test;
 mod trash_test;
 mod util;
 mod view_test;

--- a/collab-folder/tests/folder_test/space_info_test.rs
+++ b/collab-folder/tests/folder_test/space_info_test.rs
@@ -11,8 +11,8 @@ fn create_public_space_test() {
   let space_info = builder
     .is_space(true)
     .with_space_permission(SpacePermission::PublicToAll)
-    .with_space_icon_key("interface_essential/home-3")
-    .with_space_icon_color_key("0xFFA34AFD")
+    .with_space_icon(Some("interface_essential/home-3"))
+    .with_space_icon_color(Some("0xFFA34AFD"))
     .build();
   let space_info_json = serde_json::to_value(space_info).unwrap();
   assert_json_diff::assert_json_eq!(
@@ -34,8 +34,8 @@ fn create_private_space_test() {
   let space_info = builder
     .is_space(true)
     .with_space_permission(SpacePermission::Private)
-    .with_space_icon_key("interface_essential/lock")
-    .with_space_icon_color_key("0xFF4A4AFD")
+    .with_space_icon(Some("interface_essential/lock"))
+    .with_space_icon_color(Some("0xFF4A4AFD"))
     .build();
   let space_info_json = serde_json::to_value(space_info).unwrap();
   assert_json_diff::assert_json_eq!(

--- a/collab-folder/tests/folder_test/space_info_test.rs
+++ b/collab-folder/tests/folder_test/space_info_test.rs
@@ -1,0 +1,78 @@
+use collab_folder::{
+  hierarchy_builder::ViewExtraBuilder, timestamp, SpacePermission, SPACE_CREATED_AT_KEY,
+  SPACE_ICON_COLOR_KEY, SPACE_ICON_KEY, SPACE_IS_SPACE_KEY, SPACE_PERMISSION_KEY,
+};
+use serde_json::json;
+
+#[test]
+fn create_public_space_test() {
+  let builder = ViewExtraBuilder::new();
+  let timestamp = timestamp();
+  let space_info = builder
+    .is_space(true)
+    .with_space_permission(SpacePermission::PublicToAll)
+    .with_space_icon_key("interface_essential/home-3")
+    .with_space_icon_color_key("0xFFA34AFD")
+    .build();
+  let space_info_json = serde_json::to_value(space_info).unwrap();
+  assert_json_diff::assert_json_eq!(
+    space_info_json,
+    json!({
+      SPACE_IS_SPACE_KEY: true,
+      SPACE_PERMISSION_KEY: 0,
+      SPACE_ICON_KEY: "interface_essential/home-3",
+      SPACE_ICON_COLOR_KEY: "0xFFA34AFD",
+      SPACE_CREATED_AT_KEY: timestamp
+    }),
+  );
+}
+
+#[test]
+fn create_private_space_test() {
+  let builder = ViewExtraBuilder::new();
+  let timestamp = timestamp();
+  let space_info = builder
+    .is_space(true)
+    .with_space_permission(SpacePermission::Private)
+    .with_space_icon_key("interface_essential/lock")
+    .with_space_icon_color_key("0xFF4A4AFD")
+    .build();
+  let space_info_json = serde_json::to_value(space_info).unwrap();
+  assert_json_diff::assert_json_eq!(
+    space_info_json,
+    json!({
+      SPACE_IS_SPACE_KEY: true,
+      SPACE_PERMISSION_KEY: 1,
+      SPACE_ICON_KEY: "interface_essential/lock",
+      SPACE_ICON_COLOR_KEY: "0xFF4A4AFD",
+      SPACE_CREATED_AT_KEY: timestamp
+    }),
+  );
+}
+
+#[test]
+fn create_space_without_icon_and_color_test() {
+  let builder = ViewExtraBuilder::new();
+  let timestamp = timestamp();
+  let space_info = builder
+    .is_space(true)
+    .with_space_permission(SpacePermission::PublicToAll)
+    .build();
+  let space_info_json = serde_json::to_value(space_info).unwrap();
+  assert_json_diff::assert_json_eq!(
+    space_info_json,
+    json!({
+      SPACE_IS_SPACE_KEY: true,
+      SPACE_PERMISSION_KEY: 0,
+      SPACE_CREATED_AT_KEY: timestamp
+    }),
+  );
+}
+
+#[test]
+fn create_non_space_test() {
+  let builder = ViewExtraBuilder::new();
+  let space_info = builder.build();
+  let space_info_json = serde_json::to_value(space_info).unwrap();
+  assert_json_diff::assert_json_eq!(space_info_json, json!({}),);
+}

--- a/collab-importer/src/notion/importer.rs
+++ b/collab-importer/src/notion/importer.rs
@@ -4,9 +4,9 @@ use crate::notion::file::NotionFile;
 use crate::notion::page::{build_imported_collab_recursively, CollabResource, NotionPage};
 use crate::notion::walk_dir::{file_name_from_path, process_entry, walk_sub_dir};
 use collab_folder::hierarchy_builder::{
-  NestedChildViewBuilder, NestedViews, ParentChildViews, SpacePermission, ViewExtraBuilder,
+  NestedChildViewBuilder, NestedViews, ParentChildViews, ViewExtraBuilder,
 };
-use collab_folder::ViewLayout;
+use collab_folder::{SpacePermission, ViewLayout};
 use futures::stream;
 use futures::stream::{Stream, StreamExt};
 use std::collections::{HashMap, HashSet};
@@ -258,7 +258,8 @@ impl ImportedInfo {
         if space_ids.contains(&view.view.id) {
           view.view.extra = serde_json::to_string(
             &ViewExtraBuilder::new()
-              .is_space(true, SpacePermission::PublicToAll)
+              .is_space(true)
+              .with_space_permission(SpacePermission::PublicToAll)
               .build(),
           )
           .ok();

--- a/collab-importer/src/notion/importer.rs
+++ b/collab-importer/src/notion/importer.rs
@@ -6,7 +6,7 @@ use crate::notion::walk_dir::{file_name_from_path, process_entry, walk_sub_dir};
 use collab_folder::hierarchy_builder::{
   NestedChildViewBuilder, NestedViews, ParentChildViews, ViewExtraBuilder,
 };
-use collab_folder::{SpacePermission, ViewLayout};
+use collab_folder::{SpaceInfo, SpacePermission, ViewLayout};
 use futures::stream;
 use futures::stream::{Stream, StreamExt};
 use std::collections::{HashMap, HashSet};
@@ -163,7 +163,7 @@ impl ImportedInfo {
       "Imported Space",
       &view_id,
       vec![],
-      SpacePermission::PublicToAll,
+      SpaceInfo::default(),
     )?;
     Ok(Self {
       uid,

--- a/collab-importer/src/space_view.rs
+++ b/collab-importer/src/space_view.rs
@@ -3,8 +3,8 @@ use collab::core::collab::DataSource;
 use collab::core::origin::CollabOrigin;
 use collab::preclude::Collab;
 use collab_document::document_data::default_document_collab_data;
-use collab_folder::hierarchy_builder::{NestedChildViewBuilder, ParentChildViews, SpacePermission};
-use collab_folder::ViewLayout;
+use collab_folder::hierarchy_builder::{NestedChildViewBuilder, ParentChildViews};
+use collab_folder::{SpacePermission, ViewLayout};
 
 #[allow(dead_code)]
 pub fn create_space_view(
@@ -34,7 +34,12 @@ pub fn create_space_view(
     .with_layout(ViewLayout::Document)
     .with_name(name)
     .with_children(child_views)
-    .with_extra(|extra| extra.is_space(true, space_permission).build())
+    .with_extra(|extra| {
+      extra
+        .is_space(true)
+        .with_space_permission(space_permission)
+        .build()
+    })
     .build();
   Ok((view, collab))
 }

--- a/collab-importer/src/space_view.rs
+++ b/collab-importer/src/space_view.rs
@@ -4,7 +4,7 @@ use collab::core::origin::CollabOrigin;
 use collab::preclude::Collab;
 use collab_document::document_data::default_document_collab_data;
 use collab_folder::hierarchy_builder::{NestedChildViewBuilder, ParentChildViews};
-use collab_folder::{SpacePermission, ViewLayout};
+use collab_folder::{SpaceInfo, ViewLayout};
 
 #[allow(dead_code)]
 pub fn create_space_view(
@@ -13,7 +13,7 @@ pub fn create_space_view(
   name: &str,
   view_id: &str,
   child_views: Vec<ParentChildViews>,
-  space_permission: SpacePermission,
+  space_info: SpaceInfo,
 ) -> Result<(ParentChildViews, Collab), ImporterError> {
   let import_container_doc_state = default_document_collab_data(view_id)
     .map_err(|err| ImporterError::Internal(err.into()))?
@@ -34,12 +34,7 @@ pub fn create_space_view(
     .with_layout(ViewLayout::Document)
     .with_name(name)
     .with_children(child_views)
-    .with_extra(|extra| {
-      extra
-        .is_space(true)
-        .with_space_permission(space_permission)
-        .build()
-    })
+    .with_extra(|extra| extra.with_space_info(space_info).build())
     .build();
   Ok((view, collab))
 }


### PR DESCRIPTION
- Removed the hardcoded keys.
- Added an icon and icon color to the space info.
- Added more built-in functions to enhance the view's extra data.

```rs
pub struct SpaceInfo {
  /// Whether the view is a space view.
  pub is_space: bool,

  /// The permission of the space view.
  ///
  /// If the space_permission is none, the space view will use the SpacePermission::PublicToAll.
  pub space_permission: SpacePermission,

  /// The created time of the space view.
  pub space_created_at: i64,

  /// The space icon.
  ///
  /// If the space_icon is none, the space view will use the default icon.
  pub space_icon: Option<String>,

  /// The space icon color.
  ///
  /// If the space_icon_color is none, the space view will use the default icon color.
  /// The value should be a valid hex color code: 0xFFA34AFD
  pub space_icon_color: Option<String>,
}
```