### PR TITLE
chore: replace document plain text with paragraphs

### DIFF
--- a/collab-document/src/utils.rs
+++ b/collab-document/src/utils.rs
@@ -2,18 +2,31 @@ use crate::blocks::{Block, TextDelta};
 use std::collections::HashMap;
 
 #[inline]
-pub(crate) fn push_deltas_to_str(
-  buf: &mut String,
-  deltas: Vec<TextDelta>,
-  empty_space_each_delta: bool,
-) {
+pub(crate) fn push_deltas_to_str(buf: &mut String, deltas: Vec<TextDelta>) {
   for delta in deltas {
     if let TextDelta::Inserted(text, _) = delta {
-      let trimmed = text.trim();
-      if !trimmed.is_empty() {
-        buf.push_str(trimmed);
-
-        if empty_space_each_delta {
+      // trim all whitespace characters from start and end of the text
+      let mut start = 0;
+      let mut end = 0;
+      let mut i = 0;
+      for c in text.chars() {
+        i += c.len_utf8();
+        if char::is_whitespace(c) {
+          if end == 0 {
+            start += c.len_utf8();
+          }
+        } else {
+          end = i;
+        }
+      }
+      if start < end {
+        if start > 0 {
+          // if there were any whitespaces at the start, add a space before the text
+          buf.push(' ');
+        }
+        buf.push_str(&text[start..end]);
+        if end < text.len() {
+          // if there were any whitespaces at the end, add a space after the text
           buf.push(' ');
         }
       }

--- a/collab-document/tests/conversions/plain_text_test.rs
+++ b/collab-document/tests/conversions/plain_text_test.rs
@@ -20,9 +20,8 @@ fn plain_text_1_test() {
   ];
   insert_paragraphs(&mut document, paragraphs.clone());
 
-  let plain_text = document.to_plain_text(true, false).unwrap();
+  let splitted = document.paragraphs();
   // remove the empty lines at the beginning and the end
-  let splitted = plain_text.trim().split('\n').collect::<Vec<&str>>();
   // the first one and the last one are empty
   assert_eq!(splitted.len(), 8);
 

--- a/collab-document/tests/importer/md_importer_test.rs
+++ b/collab-document/tests/importer/md_importer_test.rs
@@ -15,7 +15,7 @@ fn test_override_document() {
   let doc_id = gen_document_id();
   let doc = Document::create(&doc_id, doc_data_1).unwrap();
   {
-    let plain_txt = doc.to_plain_text(false, false).unwrap();
+    let plain_txt = doc.paragraphs().join("");
     assert_eq!(markdown_1, plain_txt);
   }
 
@@ -29,7 +29,7 @@ fn test_override_document() {
   }
   {
     let modified_doc = Document::open(collab).unwrap();
-    let plain_txt = modified_doc.to_plain_text(false, false).unwrap();
+    let plain_txt = modified_doc.paragraphs().join("");
     assert_eq!(markdown_2, plain_txt);
   }
 }

--- a/collab-importer/tests/notion_test/import_test.rs
+++ b/collab-importer/tests/notion_test/import_test.rs
@@ -632,13 +632,7 @@ async fn check_project_database(linked_view: &NotionPage, include_sub_dir: bool)
         }
       }
 
-      row_document_contents.push(
-        document
-          .to_plain_text(true, false)
-          .unwrap()
-          .trim()
-          .to_string(),
-      );
+      row_document_contents.push(document.paragraphs().join("\n").trim().to_string());
     }
     assert_eq!(mention_blocks.len(), 4);
     mention_blocks.retain(|block| !linked_views.contains(&block.page_id));


### PR DESCRIPTION
This PR replaces `Document::to_plain_text` with `Document::paragraphs` returning blocks as plain text paragraph list, which is more versatile option:

1. We can group paragraphs together: for the purpose of future text chunking for the appflowy-cloud document indexer.
2. `new_line_each_paragraph` parameter is not necessary: just use `Document::paragraphs().join("\n")` if necessary.
3. `empty_space_each_delta` parameter is also not necessary: current logic trims the preceding and leading whitespaces but only adds extra spaces only if we actually trimmed the content.