### PR TITLE
fix: current view should be updated on a per user basis instead of workspace

### DIFF
--- a/collab-folder/src/space_info.rs
+++ b/collab-folder/src/space_info.rs
@@ -58,7 +58,9 @@ impl Default for SpaceInfo {
   }
 }
 
-#[derive(Debug, Clone, Default, serde_repr::Serialize_repr, serde_repr::Deserialize_repr)]
+#[derive(
+  Debug, Clone, Default, serde_repr::Serialize_repr, serde_repr::Deserialize_repr, PartialEq, Eq,
+)]
 #[repr(u8)]
 pub enum SpacePermission {
   #[default]


### PR DESCRIPTION
Current view should be set and retrieved on per user id basis, instead of per workspace. Otherwise, a user will be able to view the last visited page for another user, even if the user has no permission to view it.