### PR TITLE
fix: parent view creation time shouldn't be updated when child is added

### DIFF
--- a/collab-folder/src/view.rs
+++ b/collab-folder/src/view.rs
@@ -293,7 +293,6 @@ impl ViewsMap {
         &self.section_map,
       )
       .add_children(vec![view_identifier], index)
-      .set_created_at(time)
       .set_last_edited_time(time)
       .done()
       .map(Arc::new);


### PR DESCRIPTION
When adding new child view, the creation time of the parent shouldn't be modified.