### PR TITLE
Document history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,7 +652,6 @@ dependencies = [
  "fancy-regex",
  "futures",
  "futures-lite",
- "futures-util",
  "fxhash",
  "hex",
  "markdown",
@@ -688,7 +687,6 @@ dependencies = [
  "collab",
  "collab-entity",
  "futures",
- "futures-util",
  "getrandom 0.2.15",
  "indexed_db_futures",
  "js-sys",
@@ -1060,9 +1058,9 @@ checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-lite"
-version = "2.3.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
 dependencies = [
  "fastrand",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,6 +505,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "unicode-segmentation",
+ "uuid",
  "web-sys",
  "yrs",
 ]
@@ -2716,6 +2717,7 @@ checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
+ "serde",
  "sha1_smol",
  "wasm-bindgen",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
 ]
@@ -527,7 +527,7 @@ dependencies = [
  "dashmap 5.5.3",
  "fancy-regex",
  "futures",
- "getrandom",
+ "getrandom 0.2.15",
  "iana-time-zone",
  "js-sys",
  "lazy_static",
@@ -567,7 +567,7 @@ dependencies = [
  "collab-entity",
  "collab-plugins",
  "futures",
- "getrandom",
+ "getrandom 0.2.15",
  "markdown",
  "nanoid",
  "serde",
@@ -590,7 +590,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "collab",
- "getrandom",
+ "getrandom 0.2.15",
  "prost 0.13.3",
  "prost-build",
  "protoc-bin-vendored",
@@ -616,7 +616,7 @@ dependencies = [
  "dashmap 5.5.3",
  "fs_extra",
  "futures",
- "getrandom",
+ "getrandom 0.2.15",
  "nanoid",
  "serde",
  "serde_json",
@@ -689,7 +689,7 @@ dependencies = [
  "collab-entity",
  "futures",
  "futures-util",
- "getrandom",
+ "getrandom 0.2.15",
  "indexed_db_futures",
  "js-sys",
  "lazy_static",
@@ -726,7 +726,7 @@ dependencies = [
  "collab-entity",
  "collab-plugins",
  "fs_extra",
- "getrandom",
+ "getrandom 0.2.15",
  "nanoid",
  "serde",
  "serde_json",
@@ -979,7 +979,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -1140,8 +1140,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1283,10 +1295,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1469,7 +1482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -1926,6 +1939,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1958,7 +1977,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -2693,11 +2712,12 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
+ "js-sys",
  "sha1_smol",
  "wasm-bindgen",
 ]
@@ -2737,24 +2757,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.92"
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -2775,9 +2805,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2785,9 +2815,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2798,9 +2828,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-bindgen-test"
@@ -3023,6 +3056,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3045,9 +3045,9 @@ dependencies = [
 
 [[package]]
 name = "yrs"
-version = "0.23.5"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197c2b4b298f35c3ba4d549884ac872a961112095b29f173ab45e3d5cf609018"
+checksum = "f904a99678a852d7cbc6958c94087f739c10cfb19642635951219c525a5fdb89"
 dependencies = [
  "arc-swap",
  "async-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ collab-entity = { path = "collab-entity" }
 collab-document = { path = "collab-document" }
 collab-folder = { path = "collab-folder" }
 collab-importer = { path = "collab-importer" }
-yrs = { version = "0.23.5", features = ["sync"] }
+yrs = { version = "0.24", features = ["sync"] }
 anyhow = "1.0.94"
 thiserror = "1.0.39"
 serde = { version = "1.0.157", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ chrono = { version = "0.4.38", default-features = false, features = ["clock"] }
 async-trait = "0.1"
 arc-swap = { version = "1.7" }
 uuid = { version = "1.17.0", features = ["v4", "v5", "v7"] }
+futures-lite = { version = "2.6.0", features = ["futures-io"] }
 
 [patch.crates-io]
 # We're using a specific commit here because rust-rocksdb doesn't publish the latest version that includes the memory alignment fix.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tracing = "0.1.22"
 chrono = { version = "0.4.38", default-features = false, features = ["clock"] }
 async-trait = "0.1"
 arc-swap = { version = "1.7" }
-uuid = { version = "1.17.0", features = ["v4", "v5", "v7"] }
+uuid = { version = "1.17.0", features = ["v4", "v5", "v7", "serde"] }
 futures-lite = { version = "2.6.0", features = ["futures-io"] }
 
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tracing = "0.1.22"
 chrono = { version = "0.4.38", default-features = false, features = ["clock"] }
 async-trait = "0.1"
 arc-swap = { version = "1.7" }
+uuid = { version = "1.17.0", features = ["v4", "v5", "v7"] }
 
 [patch.crates-io]
 # We're using a specific commit here because rust-rocksdb doesn't publish the latest version that includes the memory alignment fix.

--- a/collab-database/Cargo.toml
+++ b/collab-database/Cargo.toml
@@ -21,7 +21,7 @@ nanoid = "0.4.0"
 chrono.workspace = true
 lazy_static = "1.4.0"
 async-trait.workspace = true
-uuid = { version = "1.3.3", features = ["v4", "v5"] }
+uuid.workspace = true
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 strum = "0.25"
 strum_macros = "0.25"

--- a/collab-document/Cargo.toml
+++ b/collab-document/Cargo.toml
@@ -19,7 +19,7 @@ tracing.workspace = true
 arc-swap.workspace = true
 tokio = { workspace = true, features = ["sync", "rt"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
-uuid = { version = "1.3.3", features = ["v4", "v5"] }
+uuid.workspace = true
 markdown = "1.0.0-alpha.21"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/collab-entity/Cargo.toml
+++ b/collab-entity/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-uuid = { version = "1.3.3", features = ["v4"] }
+uuid.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_repr = "0.1"

--- a/collab-entity/src/proto/collab.rs
+++ b/collab-entity/src/proto/collab.rs
@@ -3,12 +3,12 @@
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClientOrigin {
-  /// User id.
-  #[prost(int64, tag = "1")]
-  pub uid: i64,
-  /// Device id.
-  #[prost(string, tag = "2")]
-  pub device_id: ::prost::alloc::string::String,
+    /// User id.
+    #[prost(int64, tag = "1")]
+    pub uid: i64,
+    /// Device id.
+    #[prost(string, tag = "2")]
+    pub device_id: ::prost::alloc::string::String,
 }
 /// Unknown origin.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -22,212 +22,212 @@ pub struct ServerOrigin {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CollabOrigin {
-  #[prost(oneof = "collab_origin::Origin", tags = "1, 2, 3")]
-  pub origin: ::core::option::Option<collab_origin::Origin>,
+    #[prost(oneof = "collab_origin::Origin", tags = "1, 2, 3")]
+    pub origin: ::core::option::Option<collab_origin::Origin>,
 }
 /// Nested message and enum types in `CollabOrigin`.
 pub mod collab_origin {
-  #[allow(clippy::derive_partial_eq_without_eq)]
-  #[derive(Clone, PartialEq, ::prost::Oneof)]
-  pub enum Origin {
-    #[prost(message, tag = "1")]
-    Empty(super::EmptyOrigin),
-    #[prost(message, tag = "2")]
-    Client(super::ClientOrigin),
-    #[prost(message, tag = "3")]
-    Server(super::ServerOrigin),
-  }
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Origin {
+        #[prost(message, tag = "1")]
+        Empty(super::EmptyOrigin),
+        #[prost(message, tag = "2")]
+        Client(super::ClientOrigin),
+        #[prost(message, tag = "3")]
+        Server(super::ServerOrigin),
+    }
 }
 /// Collab Type.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum CollabType {
-  Unknown = 0,
-  Document = 1,
-  Database = 2,
-  WorkspaceDatabase = 3,
-  Folder = 4,
-  DatabaseRow = 5,
-  UserAwareness = 6,
+    Unknown = 0,
+    Document = 1,
+    Database = 2,
+    WorkspaceDatabase = 3,
+    Folder = 4,
+    DatabaseRow = 5,
+    UserAwareness = 6,
 }
 impl CollabType {
-  /// String value of the enum field names used in the ProtoBuf definition.
-  ///
-  /// The values are not transformed in any way and thus are considered stable
-  /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-  pub fn as_str_name(&self) -> &'static str {
-    match self {
-      CollabType::Unknown => "COLLAB_TYPE_UNKNOWN",
-      CollabType::Document => "COLLAB_TYPE_DOCUMENT",
-      CollabType::Database => "COLLAB_TYPE_DATABASE",
-      CollabType::WorkspaceDatabase => "COLLAB_TYPE_WORKSPACE_DATABASE",
-      CollabType::Folder => "COLLAB_TYPE_FOLDER",
-      CollabType::DatabaseRow => "COLLAB_TYPE_DATABASE_ROW",
-      CollabType::UserAwareness => "COLLAB_TYPE_USER_AWARENESS",
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            CollabType::Unknown => "COLLAB_TYPE_UNKNOWN",
+            CollabType::Document => "COLLAB_TYPE_DOCUMENT",
+            CollabType::Database => "COLLAB_TYPE_DATABASE",
+            CollabType::WorkspaceDatabase => "COLLAB_TYPE_WORKSPACE_DATABASE",
+            CollabType::Folder => "COLLAB_TYPE_FOLDER",
+            CollabType::DatabaseRow => "COLLAB_TYPE_DATABASE_ROW",
+            CollabType::UserAwareness => "COLLAB_TYPE_USER_AWARENESS",
+        }
     }
-  }
-  /// Creates an enum from field names used in the ProtoBuf definition.
-  pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-    match value {
-      "COLLAB_TYPE_UNKNOWN" => Some(Self::Unknown),
-      "COLLAB_TYPE_DOCUMENT" => Some(Self::Document),
-      "COLLAB_TYPE_DATABASE" => Some(Self::Database),
-      "COLLAB_TYPE_WORKSPACE_DATABASE" => Some(Self::WorkspaceDatabase),
-      "COLLAB_TYPE_FOLDER" => Some(Self::Folder),
-      "COLLAB_TYPE_DATABASE_ROW" => Some(Self::DatabaseRow),
-      "COLLAB_TYPE_USER_AWARENESS" => Some(Self::UserAwareness),
-      _ => None,
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "COLLAB_TYPE_UNKNOWN" => Some(Self::Unknown),
+            "COLLAB_TYPE_DOCUMENT" => Some(Self::Document),
+            "COLLAB_TYPE_DATABASE" => Some(Self::Database),
+            "COLLAB_TYPE_WORKSPACE_DATABASE" => Some(Self::WorkspaceDatabase),
+            "COLLAB_TYPE_FOLDER" => Some(Self::Folder),
+            "COLLAB_TYPE_DATABASE_ROW" => Some(Self::DatabaseRow),
+            "COLLAB_TYPE_USER_AWARENESS" => Some(Self::UserAwareness),
+            _ => None,
+        }
     }
-  }
 }
 /// Encoded collaborative document.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EncodedCollab {
-  /// yrs state vector
-  #[prost(bytes = "vec", tag = "1")]
-  pub state_vector: ::prost::alloc::vec::Vec<u8>,
-  /// yrs document state
-  #[prost(bytes = "vec", tag = "2")]
-  pub doc_state: ::prost::alloc::vec::Vec<u8>,
-  /// yrs encoder version used for the state vector and doc state
-  #[prost(enumeration = "EncoderVersion", tag = "3")]
-  pub encoder_version: i32,
+    /// yrs state vector
+    #[prost(bytes = "vec", tag = "1")]
+    pub state_vector: ::prost::alloc::vec::Vec<u8>,
+    /// yrs document state
+    #[prost(bytes = "vec", tag = "2")]
+    pub doc_state: ::prost::alloc::vec::Vec<u8>,
+    /// yrs encoder version used for the state vector and doc state
+    #[prost(enumeration = "EncoderVersion", tag = "3")]
+    pub encoder_version: i32,
 }
 /// yrs encoder version.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum EncoderVersion {
-  Unknown = 0,
-  V1 = 1,
-  V2 = 2,
+    Unknown = 0,
+    V1 = 1,
+    V2 = 2,
 }
 impl EncoderVersion {
-  /// String value of the enum field names used in the ProtoBuf definition.
-  ///
-  /// The values are not transformed in any way and thus are considered stable
-  /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-  pub fn as_str_name(&self) -> &'static str {
-    match self {
-      EncoderVersion::Unknown => "ENCODER_VERSION_UNKNOWN",
-      EncoderVersion::V1 => "ENCODER_VERSION_V1",
-      EncoderVersion::V2 => "ENCODER_VERSION_V2",
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            EncoderVersion::Unknown => "ENCODER_VERSION_UNKNOWN",
+            EncoderVersion::V1 => "ENCODER_VERSION_V1",
+            EncoderVersion::V2 => "ENCODER_VERSION_V2",
+        }
     }
-  }
-  /// Creates an enum from field names used in the ProtoBuf definition.
-  pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-    match value {
-      "ENCODER_VERSION_UNKNOWN" => Some(Self::Unknown),
-      "ENCODER_VERSION_V1" => Some(Self::V1),
-      "ENCODER_VERSION_V2" => Some(Self::V2),
-      _ => None,
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "ENCODER_VERSION_UNKNOWN" => Some(Self::Unknown),
+            "ENCODER_VERSION_V1" => Some(Self::V1),
+            "ENCODER_VERSION_V2" => Some(Self::V2),
+            _ => None,
+        }
     }
-  }
 }
 /// Embeddings and the associated collab metadata.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CollabEmbeddingsParams {
-  /// Fragment id.
-  #[prost(string, tag = "1")]
-  pub fragment_id: ::prost::alloc::string::String,
-  /// Collab object id.
-  #[prost(string, tag = "2")]
-  pub object_id: ::prost::alloc::string::String,
-  /// Collab type.
-  #[prost(enumeration = "CollabType", tag = "3")]
-  pub collab_type: i32,
-  /// Embedding content type.
-  #[prost(enumeration = "EmbeddingContentType", tag = "4")]
-  pub content_type: i32,
-  /// Embedding content as string.
-  #[prost(string, tag = "5")]
-  pub content: ::prost::alloc::string::String,
-  /// Embedding as float array.
-  #[prost(float, repeated, tag = "6")]
-  pub embedding: ::prost::alloc::vec::Vec<f32>,
+    /// Fragment id.
+    #[prost(string, tag = "1")]
+    pub fragment_id: ::prost::alloc::string::String,
+    /// Collab object id.
+    #[prost(string, tag = "2")]
+    pub object_id: ::prost::alloc::string::String,
+    /// Collab type.
+    #[prost(enumeration = "CollabType", tag = "3")]
+    pub collab_type: i32,
+    /// Embedding content type.
+    #[prost(enumeration = "EmbeddingContentType", tag = "4")]
+    pub content_type: i32,
+    /// Embedding content as string.
+    #[prost(string, tag = "5")]
+    pub content: ::prost::alloc::string::String,
+    /// Embedding as float array.
+    #[prost(float, repeated, tag = "6")]
+    pub embedding: ::prost::alloc::vec::Vec<f32>,
 }
 /// Wrapper over a collection of embeddings, together with metadata associated on the collection level.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CollabEmbeddings {
-  /// OpenAPI tokens consumed.
-  #[prost(uint32, tag = "1")]
-  pub tokens_consumed: u32,
-  /// List of embeddings.
-  #[prost(message, repeated, tag = "2")]
-  pub embeddings: ::prost::alloc::vec::Vec<CollabEmbeddingsParams>,
+    /// OpenAPI tokens consumed.
+    #[prost(uint32, tag = "1")]
+    pub tokens_consumed: u32,
+    /// List of embeddings.
+    #[prost(message, repeated, tag = "2")]
+    pub embeddings: ::prost::alloc::vec::Vec<CollabEmbeddingsParams>,
 }
 /// Payload for sending and receive collab over http.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CollabParams {
-  #[prost(string, tag = "1")]
-  pub object_id: ::prost::alloc::string::String,
-  /// Serialized EncodedCollab object, which could either be in bincode or protobuf serialization format.
-  #[prost(bytes = "vec", tag = "2")]
-  pub encoded_collab: ::prost::alloc::vec::Vec<u8>,
-  /// Collab type.
-  #[prost(enumeration = "CollabType", tag = "3")]
-  pub collab_type: i32,
-  /// Document embeddings.
-  #[prost(message, optional, tag = "4")]
-  pub embeddings: ::core::option::Option<CollabEmbeddings>,
+    #[prost(string, tag = "1")]
+    pub object_id: ::prost::alloc::string::String,
+    /// Serialized EncodedCollab object, which could either be in bincode or protobuf serialization format.
+    #[prost(bytes = "vec", tag = "2")]
+    pub encoded_collab: ::prost::alloc::vec::Vec<u8>,
+    /// Collab type.
+    #[prost(enumeration = "CollabType", tag = "3")]
+    pub collab_type: i32,
+    /// Document embeddings.
+    #[prost(message, optional, tag = "4")]
+    pub embeddings: ::core::option::Option<CollabEmbeddings>,
 }
 /// Payload for creating batch of collab over http.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BatchCreateCollabParams {
-  /// Workspace id.
-  #[prost(string, tag = "1")]
-  pub workspace_id: ::prost::alloc::string::String,
-  /// List of collab params.
-  #[prost(message, repeated, tag = "2")]
-  pub params_list: ::prost::alloc::vec::Vec<CollabParams>,
+    /// Workspace id.
+    #[prost(string, tag = "1")]
+    pub workspace_id: ::prost::alloc::string::String,
+    /// List of collab params.
+    #[prost(message, repeated, tag = "2")]
+    pub params_list: ::prost::alloc::vec::Vec<CollabParams>,
 }
 /// Payload for creating new collab or update existing collab over http.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateCollabParams {
-  /// Workspace id.
-  #[prost(string, tag = "1")]
-  pub workspace_id: ::prost::alloc::string::String,
-  /// Object id.
-  #[prost(string, tag = "2")]
-  pub object_id: ::prost::alloc::string::String,
-  /// Serialized EncodedCollab object, which could either be in bincode or protobuf serialization format.
-  #[prost(bytes = "vec", tag = "3")]
-  pub encoded_collab: ::prost::alloc::vec::Vec<u8>,
-  /// Collab type.
-  #[prost(enumeration = "CollabType", tag = "4")]
-  pub collab_type: i32,
+    /// Workspace id.
+    #[prost(string, tag = "1")]
+    pub workspace_id: ::prost::alloc::string::String,
+    /// Object id.
+    #[prost(string, tag = "2")]
+    pub object_id: ::prost::alloc::string::String,
+    /// Serialized EncodedCollab object, which could either be in bincode or protobuf serialization format.
+    #[prost(bytes = "vec", tag = "3")]
+    pub encoded_collab: ::prost::alloc::vec::Vec<u8>,
+    /// Collab type.
+    #[prost(enumeration = "CollabType", tag = "4")]
+    pub collab_type: i32,
 }
 /// Types of embeddings content.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum EmbeddingContentType {
-  /// Unknown content type.
-  Unknown = 0,
-  /// Plain text
-  PlainText = 1,
+    /// Unknown content type.
+    Unknown = 0,
+    /// Plain text
+    PlainText = 1,
 }
 impl EmbeddingContentType {
-  /// String value of the enum field names used in the ProtoBuf definition.
-  ///
-  /// The values are not transformed in any way and thus are considered stable
-  /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-  pub fn as_str_name(&self) -> &'static str {
-    match self {
-      EmbeddingContentType::Unknown => "EMBEDDING_CONTENT_TYPE_UNKNOWN",
-      EmbeddingContentType::PlainText => "EMBEDDING_CONTENT_TYPE_PLAIN_TEXT",
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            EmbeddingContentType::Unknown => "EMBEDDING_CONTENT_TYPE_UNKNOWN",
+            EmbeddingContentType::PlainText => "EMBEDDING_CONTENT_TYPE_PLAIN_TEXT",
+        }
     }
-  }
-  /// Creates an enum from field names used in the ProtoBuf definition.
-  pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-    match value {
-      "EMBEDDING_CONTENT_TYPE_UNKNOWN" => Some(Self::Unknown),
-      "EMBEDDING_CONTENT_TYPE_PLAIN_TEXT" => Some(Self::PlainText),
-      _ => None,
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "EMBEDDING_CONTENT_TYPE_UNKNOWN" => Some(Self::Unknown),
+            "EMBEDDING_CONTENT_TYPE_PLAIN_TEXT" => Some(Self::PlainText),
+            _ => None,
+        }
     }
-  }
 }

--- a/collab-folder/Cargo.toml
+++ b/collab-folder/Cargo.toml
@@ -21,7 +21,7 @@ tokio-stream = { version = "0.1.14", features = ["sync"] }
 tracing.workspace = true
 dashmap = "5"
 arc-swap = "1.7"
-uuid = "1.10"
+uuid.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
@@ -36,5 +36,4 @@ tokio = { version = "1.26", features = ["rt", "macros"] }
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 walkdir = "2.3.2"
 zip = "0.6.6"
-uuid = { version = "1.6.1", features = ["v4"] }
 futures = "0.3.30"

--- a/collab-folder/src/folder.rs
+++ b/collab-folder/src/folder.rs
@@ -17,7 +17,6 @@ use crate::folder_observe::ViewChangeSender;
 use crate::hierarchy_builder::{FlattedViews, ParentChildViews};
 use crate::revision::RevisionMapping;
 use crate::section::{Section, SectionItem, SectionMap};
-use crate::view::view_from_map_ref;
 use crate::{
   FolderData, ParentChildRelations, SectionChangeSender, SpacePermission, TrashInfo, View,
   ViewChangeReceiver, ViewUpdate, ViewsMap, Workspace, impl_section_op,
@@ -816,7 +815,7 @@ impl FolderBody {
     new_view_id: &str,
     uid: i64,
   ) -> bool {
-    self.views.replace_view(txn, &old_view_id, new_view_id, uid)
+    self.views.replace_view(txn, old_view_id, new_view_id, uid)
   }
 }
 

--- a/collab-folder/src/lib.rs
+++ b/collab-folder/src/lib.rs
@@ -24,4 +24,5 @@ pub mod folder_diff;
 mod folder_migration;
 mod folder_observe;
 pub mod hierarchy_builder;
+mod revision;
 pub mod space_info;

--- a/collab-folder/src/relation.rs
+++ b/collab-folder/src/relation.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
-use collab::preclude::{Any, MapExt, MapRef, YrsValue};
+use collab::preclude::{Any, Map, MapExt, MapRef, Out, YrsValue};
 use collab::preclude::{Array, ArrayRef, ReadTxn, TransactionMut};
 use serde::{Deserialize, Serialize};
 
@@ -152,6 +152,36 @@ impl ParentChildRelations {
     let array = self.get_or_create_children_with_txn(txn, parent_id);
     array.add_children_with_txn(txn, children, index);
   }
+
+  /*pub fn replace_view(&self, txn: &mut TransactionMut, old_view_id: &str, new_view_id: &str) {
+    /*
+      We cannot replace the view id with the parent id, because if another person would add a child
+      to the previous parent view id at the same time, it wouldn't be migrated to the new view id.
+      For that reason we'll use [RevisionMapping] to keep track of the view ids for this case.
+    */
+
+    // replace the view id in children array
+    for (parent_id) in self.container.keys(txn) {
+      if let Some(children) = self.get_children_with_txn(txn, parent_id) {
+        for (index, id) in children
+          .get_children_with_txn(txn)
+          .items
+          .into_iter()
+          .enumerate()
+        {
+          if id.id == old_view_id {
+            children.remove_child_with_txn(txn, index as u32);
+            children.insert_child_with_txn(
+              txn,
+              index as u32,
+              ViewIdentifier::new(new_view_id.to_string()),
+            );
+            return;
+          }
+        }
+      }
+    }
+  }*/
 }
 
 /// Handy wrapper around an array of children.

--- a/collab-folder/src/relation.rs
+++ b/collab-folder/src/relation.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
-use collab::preclude::{Any, Map, MapExt, MapRef, Out, YrsValue};
+use collab::preclude::{Any, MapExt, MapRef, YrsValue};
 use collab::preclude::{Array, ArrayRef, ReadTxn, TransactionMut};
 use serde::{Deserialize, Serialize};
 

--- a/collab-folder/src/revision.rs
+++ b/collab-folder/src/revision.rs
@@ -1,5 +1,4 @@
 use collab::preclude::{Any, Map, MapRef, Out, ReadTxn, TransactionMut};
-use std::sync::Arc;
 
 pub struct RevisionMapping {
   container: MapRef,

--- a/collab-folder/src/revision.rs
+++ b/collab-folder/src/revision.rs
@@ -1,0 +1,69 @@
+use collab::preclude::{Any, Map, MapRef, Out, ReadTxn, TransactionMut};
+use std::sync::Arc;
+
+pub struct RevisionMapping {
+  container: MapRef,
+}
+
+impl RevisionMapping {
+  /// The maximum number of jumps to prevent infinite loops in the revision map.
+  const REVISION_MAP_JUMP_LIMIT: usize = 1000;
+
+  pub fn new(container: MapRef) -> Self {
+    Self { container }
+  }
+
+  pub fn contains_key<T: ReadTxn>(&self, txn: &T, key: &str) -> bool {
+    self.container.contains_key(txn, key)
+  }
+
+  pub fn replace_view(&self, txn: &mut TransactionMut, old_view_id: &str, new_view_id: &str) {
+    if self.container.contains_key(txn, new_view_id) {
+      // new view id should not already exist in the revision map, otherwise it could create a cycle
+      panic!(
+        "new view_id {} already exists in the revision map",
+        new_view_id
+      );
+    }
+
+    self.container.insert(txn, old_view_id, new_view_id);
+  }
+
+  pub fn mappings(&self, txn: &impl ReadTxn, view_id: String) -> (String, Vec<String>) {
+    let mut buf = Vec::new();
+    let last_view_id = self.iter_mapping(txn, view_id, |view_id| {
+      buf.push(view_id);
+    });
+    (last_view_id, buf)
+  }
+
+  pub fn map<T: ReadTxn>(&self, txn: &T, view_id: String) -> String {
+    self.iter_mapping(txn, view_id, |_| {})
+  }
+
+  fn iter_mapping<T, F>(&self, txn: &T, view_id: String, mut f: F) -> String
+  where
+    T: ReadTxn,
+    F: FnMut(String),
+  {
+    let mut current_view_id = view_id;
+    let mut i = Self::REVISION_MAP_JUMP_LIMIT;
+    while i > 0 {
+      if let Some(Out::Any(Any::String(next_view_id))) = self.container.get(txn, &current_view_id) {
+        let next_view_id = next_view_id.to_string();
+        let old_view_id = std::mem::replace(&mut current_view_id, next_view_id);
+        f(old_view_id);
+        i -= 1;
+      } else {
+        break;
+      }
+    }
+    if i == 0 {
+      panic!(
+        "Infinite loop detected in revision map for view_id: {}",
+        current_view_id
+      );
+    }
+    current_view_id
+  }
+}

--- a/collab-folder/src/section.rs
+++ b/collab-folder/src/section.rs
@@ -4,7 +4,7 @@ use crate::{UserId, timestamp};
 use anyhow::bail;
 use collab::preclude::encoding::serde::{from_any, to_any};
 use collab::preclude::{
-  Any, AnyMut, Array, Map, MapRef, Out, ReadTxn, Subscription, TransactionMut, YrsValue,
+  Any, AnyMut, Array, Map, MapRef, ReadTxn, Subscription, TransactionMut, YrsValue,
 };
 use collab::preclude::{ArrayRef, MapExt, deserialize_i64_from_numeric};
 use serde::{Deserialize, Serialize};

--- a/collab-folder/src/section.rs
+++ b/collab-folder/src/section.rs
@@ -4,7 +4,7 @@ use crate::{UserId, timestamp};
 use anyhow::bail;
 use collab::preclude::encoding::serde::{from_any, to_any};
 use collab::preclude::{
-  Any, AnyMut, Array, Map, MapRef, ReadTxn, Subscription, TransactionMut, YrsValue,
+  Any, AnyMut, Array, Map, MapRef, Out, ReadTxn, Subscription, TransactionMut, YrsValue,
 };
 use collab::preclude::{ArrayRef, MapExt, deserialize_i64_from_numeric};
 use serde::{Deserialize, Serialize};

--- a/collab-folder/src/view.rs
+++ b/collab-folder/src/view.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 
 use anyhow::bail;
 use collab::preclude::{
-  Any, AsPrelim, Map, MapExt, MapPrelim, MapRef, Out, ReadTxn, Subscription, TransactionMut,
-  YrsValue,
+  Any, Map, MapExt, MapPrelim, MapRef, ReadTxn, Subscription, TransactionMut,
 };
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
@@ -225,7 +224,7 @@ impl ViewsMap {
       .collect();
 
     for view_id in roots {
-      let (leaf, mappings) = self.revision_map.mappings(txn, view_id.to_string());
+      let (_, mappings) = self.revision_map.mappings(txn, view_id.to_string());
       let values = mapped
         .entry(view_id.to_string())
         .or_insert_with(HashSet::new);

--- a/collab-folder/src/view.rs
+++ b/collab-folder/src/view.rs
@@ -1,9 +1,10 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use anyhow::bail;
 use collab::preclude::{
-  Any, Map, MapExt, MapPrelim, MapRef, ReadTxn, Subscription, TransactionMut, YrsValue,
+  Any, AsPrelim, Map, MapExt, MapPrelim, MapRef, Out, ReadTxn, Subscription, TransactionMut,
+  YrsValue,
 };
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
@@ -13,6 +14,7 @@ use tracing::{instrument, trace};
 
 use crate::folder_observe::ViewChangeSender;
 
+use crate::revision::RevisionMapping;
 use crate::section::{Section, SectionItem, SectionMap};
 use crate::space_info::SpaceInfo;
 use crate::{ParentChildRelations, RepeatedViewIdentifier, ViewIdentifier, subscribe_view_change};
@@ -40,6 +42,7 @@ pub struct ViewsMap {
   pub(crate) container: MapRef,
   pub(crate) parent_children_relation: Arc<ParentChildRelations>,
   pub(crate) section_map: Arc<SectionMap>,
+  pub(crate) revision_map: Arc<RevisionMapping>,
   // Minimal cache only for deletion notifications - stores basic view info
   deletion_cache: Arc<DashMap<String, Arc<View>>>,
   subscription: Mutex<Option<Subscription>>,
@@ -52,6 +55,7 @@ impl ViewsMap {
     change_tx: Option<ViewChangeSender>,
     view_relations: Arc<ParentChildRelations>,
     section_map: Arc<SectionMap>,
+    revision_map: Arc<RevisionMapping>,
   ) -> ViewsMap {
     trace!("Initializing ViewsMap with deletion cache for proper deletion notifications");
     // Initialize deletion cache with existing views
@@ -61,6 +65,7 @@ impl ViewsMap {
       change_tx,
       parent_children_relation: view_relations,
       section_map,
+      revision_map,
       deletion_cache: Arc::new(DashMap::new()),
     }
   }
@@ -76,6 +81,7 @@ impl ViewsMap {
         change_tx.clone(),
         self.parent_children_relation.clone(),
         self.section_map.clone(),
+        self.revision_map.clone(),
         uid,
       )
     });
@@ -156,9 +162,10 @@ impl ViewsMap {
         .iter()
         .flat_map(|child| {
           // Always load fresh from storage
+          let (child_id, mappings) = self.revision_map.mappings(txn, child.id.clone());
           self
             .container
-            .get_with_txn(txn, &child.id)
+            .get_with_txn(txn, &child_id)
             .and_then(|map| {
               view_from_map_ref(
                 &map,
@@ -166,6 +173,7 @@ impl ViewsMap {
                 &self.parent_children_relation,
                 &self.section_map,
                 uid,
+                mappings,
               )
             })
             .map(Arc::new)
@@ -203,19 +211,40 @@ impl ViewsMap {
   }
 
   pub fn get_all_views<T: ReadTxn>(&self, txn: &T, uid: i64) -> Vec<Arc<View>> {
-    self
+    // since views can be mapped through revisions, we need a map of final_view_id and its predecessors
+
+    // first split the keys into ones that have existing mappings (roots) and ones that have not more mapping (leafs)
+    let (roots, leafs): (Vec<_>, Vec<_>) = self
       .container
-      .iter(txn)
-      .flat_map(|(_, v)| match v {
-        YrsValue::YMap(map) => view_from_map_ref(
-          &map,
+      .keys(txn)
+      .partition(|view_id| self.revision_map.contains_key(txn, view_id));
+
+    let mut mapped: HashMap<_, _> = leafs
+      .into_iter()
+      .map(|view_id| (view_id.to_string(), HashSet::new()))
+      .collect();
+
+    for view_id in roots {
+      let (leaf, mappings) = self.revision_map.mappings(txn, view_id.to_string());
+      let values = mapped
+        .entry(view_id.to_string())
+        .or_insert_with(HashSet::new);
+      values.extend(mappings);
+    }
+
+    mapped
+      .into_iter()
+      .flat_map(|(final_id, predecessors)| {
+        let map_ref = self.container.get_with_txn(txn, &final_id)?;
+        view_from_map_ref(
+          &map_ref,
           txn,
           &self.parent_children_relation,
           &self.section_map,
           uid,
+          predecessors,
         )
-        .map(Arc::new),
-        _ => None,
+        .map(Arc::new)
       })
       .collect()
   }
@@ -243,13 +272,15 @@ impl ViewsMap {
     view_id: &str,
     uid: i64,
   ) -> Option<Arc<View>> {
-    let map_ref = self.container.get_with_txn(txn, view_id)?;
+    let (view_id, mappings) = self.revision_map.mappings(txn, view_id.into());
+    let map_ref = self.container.get_with_txn(txn, &view_id)?;
     view_from_map_ref(
       &map_ref,
       txn,
       &self.parent_children_relation,
       &self.section_map,
       uid,
+      mappings,
     )
     .map(Arc::new)
   }
@@ -434,6 +465,31 @@ impl ViewsMap {
       timestamp
     }
   }
+
+  pub fn replace_view(
+    &self,
+    txn: &mut TransactionMut,
+    old_view_id: &str,
+    new_view_id: &str,
+    uid: i64,
+  ) -> bool {
+    if let Some(old_view) = self.get_view(txn, old_view_id, uid) {
+      let mut new_view = (*old_view).clone();
+      new_view.id = new_view_id.to_string();
+      new_view.last_edited_by = Some(uid);
+      new_view.last_edited_time = timestamp();
+
+      self.insert(txn, new_view, None, uid);
+
+      self
+        .revision_map
+        .replace_view(txn, old_view_id, new_view_id);
+
+      true
+    } else {
+      false
+    }
+  }
 }
 
 pub(crate) fn view_from_map_ref<T: ReadTxn>(
@@ -442,6 +498,7 @@ pub(crate) fn view_from_map_ref<T: ReadTxn>(
   view_relations: &Arc<ParentChildRelations>,
   section_map: &SectionMap,
   uid: i64,
+  mappings: impl IntoIterator<Item = String>,
 ) -> Option<View> {
   let parent_view_id: String = map_ref.get_with_txn(txn, VIEW_PARENT_ID)?;
   let id: String = map_ref.get_with_txn(txn, FOLDER_VIEW_ID)?;
@@ -455,10 +512,22 @@ pub(crate) fn view_from_map_ref<T: ReadTxn>(
     .get_with_txn::<_, i64>(txn, VIEW_LAYOUT)
     .and_then(|v| v.try_into().ok())?;
 
-  let children = view_relations
+  let mut children = view_relations
     .get_children_with_txn(txn, &id)
     .map(|array| array.get_children_with_txn(txn))
     .unwrap_or_default();
+
+  for view_id in mappings {
+    let ids = view_relations
+      .get_children_with_txn(txn, &view_id)
+      .map(|array| array.get_children_with_txn(txn))
+      .unwrap_or_default();
+    for view_id in ids.items {
+      if !children.items.contains(&view_id) {
+        children.items.push(view_id);
+      }
+    }
+  }
 
   let icon = get_icon_from_view_map(map_ref, txn);
   let is_favorite = section_map
@@ -688,6 +757,7 @@ impl<'a, 'b, 'c> ViewUpdate<'a, 'b, 'c> {
       &self.children_map,
       self.section_map,
       self.uid.as_i64(),
+      [],
     )
   }
 }

--- a/collab-folder/tests/folder_test/main.rs
+++ b/collab-folder/tests/folder_test/main.rs
@@ -3,6 +3,7 @@ mod custom_section;
 mod favorite_test;
 mod load_disk;
 // mod recent_views_test;
+mod replace_view_test;
 mod serde_test;
 mod space_info_test;
 mod trash_test;

--- a/collab-folder/tests/folder_test/replace_view_test.rs
+++ b/collab-folder/tests/folder_test/replace_view_test.rs
@@ -1,0 +1,90 @@
+use crate::util::{FolderTest, create_folder, make_test_view};
+use collab::preclude::updates::decoder::Decode;
+use collab::preclude::{Collab, Update};
+use collab_folder::{Folder, FolderData, UserId};
+
+#[test]
+fn replace_view_get_view() {
+  let uid = 1i64;
+  let mut folder = create_folder(UserId::from(uid), "fake_workspace_id");
+  let workspace_id = folder.get_workspace_id().unwrap();
+
+  // Create initial views
+  let v1 = make_test_view("v1", &workspace_id, vec![]);
+  let v21 = make_test_view("v2.1", &workspace_id, vec![]);
+  let v22 = make_test_view("v2.2", &workspace_id, vec![]);
+  let v2 = make_test_view("v2", &workspace_id, vec!["v2.1".to_string(), "v2.2".into()]);
+  folder.insert_view(v1, None, uid);
+  folder.insert_view(v21, None, uid);
+  folder.insert_view(v22, None, uid);
+  folder.insert_view(v2, None, uid);
+
+  let old = folder.get_view("v2", uid).unwrap();
+  assert_eq!(old.id, "v2");
+
+  folder.replace_view("v2", "v3", uid);
+
+  // getting old view id should return new one
+  let new = folder.get_view("v2", uid).unwrap();
+  assert_eq!(new.id, "v3");
+  assert_eq!(new.name, old.name);
+  assert_eq!(new.parent_view_id, old.parent_view_id);
+  assert_eq!(new.children, old.children);
+  assert_eq!(new.layout, old.layout);
+  assert_eq!(new.icon, old.icon);
+}
+
+#[test]
+fn replace_view_get_view_concurrent_update() {
+  let uid1 = 1i64;
+  let uid2 = 1i64;
+  let mut f1 = create_folder(UserId::from(uid1), "fake_workspace_id");
+  let workspace_id = f1.get_workspace_id().unwrap();
+
+  // Create initial views
+  let v1 = make_test_view("v1", &workspace_id, vec![]);
+  let v21 = make_test_view("v2.1", &workspace_id, vec![]);
+  let v22 = make_test_view("v2.2", &workspace_id, vec![]);
+  let v2 = make_test_view("v2", &workspace_id, vec!["v2.1".to_string(), "v2.2".into()]);
+  f1.insert_view(v1, None, uid1);
+  f1.insert_view(v21, None, uid1);
+  f1.insert_view(v22, None, uid1);
+  f1.insert_view(v2, None, uid1);
+
+  let mut collab = Collab::new(uid2, "fake_workspace_id", "device-2", 2);
+
+  // sync initial state between f1 and f2
+  collab
+    .apply_update(Update::decode_v2(&f1.encode_collab_v2().doc_state).unwrap())
+    .unwrap();
+  let mut f2 = Folder::open(collab, None).unwrap();
+
+  assert_eq!(f1.to_json_value(), f2.to_json_value());
+
+  // concurrently replace view in f1 and add new child view in f2
+  f1.replace_view("v2", "v3", uid1);
+
+  let mut v23 = make_test_view("v2.3", &workspace_id, vec![]);
+  v23.parent_view_id = "v2".to_string();
+  f2.insert_view(v23, None, uid2);
+
+  // cross-sync state between f1 and f2
+  f2.apply_update(Update::decode_v2(&f1.encode_collab_v2().doc_state).unwrap())
+    .unwrap();
+  f1.apply_update(Update::decode_v2(&f2.encode_collab_v2().doc_state).unwrap())
+    .unwrap();
+
+  let view = f1.get_view("v2", uid2).unwrap();
+  assert_eq!(view.id, "v3");
+  assert_eq!(
+    view
+      .children
+      .iter()
+      .map(|c| c.id.clone())
+      .collect::<Vec<_>>(),
+    vec!["v2.1", "v2.2", "v2.3"]
+  );
+
+  let other_view = f2.get_view("v2", uid1).unwrap();
+  assert_eq!(view, other_view);
+}

--- a/collab-folder/tests/folder_test/replace_view_test.rs
+++ b/collab-folder/tests/folder_test/replace_view_test.rs
@@ -74,17 +74,65 @@ fn replace_view_get_view_concurrent_update() {
   f1.apply_update(Update::decode_v2(&f2.encode_collab_v2().doc_state).unwrap())
     .unwrap();
 
-  let view = f1.get_view("v2", uid2).unwrap();
-  assert_eq!(view.id, "v3");
+  let v1 = f1.get_view("v2", uid2).unwrap();
+  assert_eq!(v1.id, "v3");
   assert_eq!(
-    view
-      .children
-      .iter()
-      .map(|c| c.id.clone())
-      .collect::<Vec<_>>(),
+    v1.children.iter().map(|c| c.id.clone()).collect::<Vec<_>>(),
     vec!["v2.1", "v2.2", "v2.3"]
   );
 
-  let other_view = f2.get_view("v2", uid1).unwrap();
-  assert_eq!(view, other_view);
+  let v2 = f2.get_view("v2", uid1).unwrap();
+  assert_eq!(v1, v2);
+}
+
+#[test]
+fn replace_view_all_views_concurrent_update() {
+  let uid1 = 1i64;
+  let uid2 = 1i64;
+  let mut f1 = create_folder(UserId::from(uid1), "fake_workspace_id");
+  let workspace_id = f1.get_workspace_id().unwrap();
+
+  // Create initial views
+  let v1 = make_test_view("v1", &workspace_id, vec![]);
+  let v21 = make_test_view("v2.1", &workspace_id, vec![]);
+  let v22 = make_test_view("v2.2", &workspace_id, vec![]);
+  let v2 = make_test_view("v2", &workspace_id, vec!["v2.1".to_string(), "v2.2".into()]);
+  f1.insert_view(v1, None, uid1);
+  f1.insert_view(v21, None, uid1);
+  f1.insert_view(v22, None, uid1);
+  f1.insert_view(v2, None, uid1);
+
+  let mut collab = Collab::new(uid2, "fake_workspace_id", "device-2", 2);
+
+  // sync initial state between f1 and f2
+  collab
+    .apply_update(Update::decode_v2(&f1.encode_collab_v2().doc_state).unwrap())
+    .unwrap();
+  let mut f2 = Folder::open(collab, None).unwrap();
+
+  assert_eq!(f1.to_json_value(), f2.to_json_value());
+
+  // concurrently replace view in f1 and add new child view in f2
+  f1.replace_view("v2", "v3", uid1);
+
+  let mut v23 = make_test_view("v2.3", &workspace_id, vec![]);
+  v23.parent_view_id = "v2".to_string();
+  f2.insert_view(v23, None, uid2);
+
+  // cross-sync state between f1 and f2
+  f2.apply_update(Update::decode_v2(&f1.encode_collab_v2().doc_state).unwrap())
+    .unwrap();
+  f1.apply_update(Update::decode_v2(&f2.encode_collab_v2().doc_state).unwrap())
+    .unwrap();
+
+  // check if both sides have the same views
+  assert_eq!(f1.to_json_value(), f2.to_json_value());
+
+  let mut v1 = f1.get_all_views(uid1);
+  let mut v2 = f2.get_all_views(uid2);
+
+  v1.sort_by_key(|v| v.id.clone());
+  v2.sort_by_key(|v| v.id.clone());
+
+  assert_eq!(v1, v2);
 }

--- a/collab-folder/tests/folder_test/replace_view_test.rs
+++ b/collab-folder/tests/folder_test/replace_view_test.rs
@@ -1,7 +1,7 @@
-use crate::util::{FolderTest, create_folder, make_test_view};
+use crate::util::{create_folder, make_test_view};
 use collab::preclude::updates::decoder::Decode;
 use collab::preclude::{Collab, Update};
-use collab_folder::{Folder, FolderData, UserId};
+use collab_folder::{Folder, UserId};
 
 #[test]
 fn replace_view_get_view() {

--- a/collab-importer/Cargo.toml
+++ b/collab-importer/Cargo.toml
@@ -33,8 +33,7 @@ async_zip = { version = "0.0.17", features = ["full"] }
 async-trait.workspace = true
 futures = "0.3.30"
 async-recursion = "1.1"
-futures-util = "0.3.30"
-futures-lite = "2.3.0"
+futures-lite.workspace = true
 sanitize-filename = "0.5.0"
 zip = "0.6.6"
 csv = { version = "1.3.0" }

--- a/collab-importer/Cargo.toml
+++ b/collab-importer/Cargo.toml
@@ -15,7 +15,7 @@ thiserror.workspace = true
 anyhow.workspace = true
 chrono.workspace = true
 walkdir = "2.5.0"
-uuid = "1.6.1"
+uuid.workspace = true
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"
 markdown = "1.0.0-alpha.21"

--- a/collab-plugins/Cargo.toml
+++ b/collab-plugins/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib", "rlib"]
 yrs.workspace = true
 collab-entity = { workspace = true }
 
-futures-util = { version = "0.3", features = ["sink"] }
 tokio = { workspace = true, features = ["sync", "rt", "macros"] }
+futures = { version = "0.3" }
 tracing.workspace = true
 anyhow.workspace = true
 
@@ -43,7 +43,6 @@ rand = { version = "0.8" }
 tempfile = "3.8.0"
 assert-json-diff = "2.0.2"
 tokio-util = { version = "0.7", features = ["codec"] }
-futures = "0.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
@@ -51,7 +50,6 @@ collab = { workspace = true }
 indexed_db_futures = { version = "0.4" }
 js-sys = "0.3"
 async-stream = "0.3"
-futures = "0.3"
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["console", "Window"] }
 wasm-bindgen-futures = "0.4"

--- a/collab-plugins/Cargo.toml
+++ b/collab-plugins/Cargo.toml
@@ -23,7 +23,7 @@ serde.workspace = true
 serde_json.workspace = true
 similar = { version = "2.2.1" }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
-uuid = { version = "1.3.3", features = ["v4"] }
+uuid.workspace = true
 bytes.workspace = true
 rand = { version = "0.8", optional = true }
 lazy_static = "1.4.0"

--- a/collab-plugins/src/cloud_storage/channel.rs
+++ b/collab-plugins/src/cloud_storage/channel.rs
@@ -1,11 +1,10 @@
+use crate::cloud_storage::error::SyncError;
+use futures::Sink;
 use std::fmt::Debug;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-
-use futures_util::{Sink, Stream};
 use tokio::sync::mpsc::UnboundedSender;
-
-use crate::cloud_storage::error::SyncError;
+use tokio_stream::Stream;
 
 #[allow(dead_code)]
 pub trait CollabConnect<Item>: Sink<Item> + Stream {}

--- a/collab-plugins/src/cloud_storage/remote_collab.rs
+++ b/collab-plugins/src/cloud_storage/remote_collab.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, SystemTime};
 
 use anyhow::{Error, anyhow};
 use async_trait::async_trait;
-use collab::core::collab::{DataSource, TransactionMutExt};
+use collab::core::collab::{CollabOptions, DataSource, TransactionMutExt, default_client_id};
 use collab::core::collab_state::SyncState;
 use collab::core::origin::CollabOrigin;
 use collab::lock::RwLock;
@@ -60,12 +60,10 @@ impl RemoteCollab {
   ) -> Self {
     let is_init_sync_finish = Arc::new(AtomicBool::new(false));
     let sync_state = Arc::new(watch::channel(SyncState::InitSyncBegin).0);
-    let collab = Arc::new(RwLock::from(Collab::new_with_origin(
-      CollabOrigin::Server,
-      &object.object_id,
-      vec![],
-      true,
-    )));
+    let options = CollabOptions::new(object.object_id.clone(), default_client_id());
+    let collab = Arc::new(RwLock::from(
+      Collab::new_with_options(CollabOrigin::Server, options).unwrap(),
+    ));
     let (sink, mut stream) = unbounded_channel::<Message>();
     let weak_storage = Arc::downgrade(&storage);
     let (notifier, notifier_rx) = watch::channel(false);

--- a/collab-plugins/src/cloud_storage/sink.rs
+++ b/collab-plugins/src/cloud_storage/sink.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Weak};
 use std::time::Duration;
 
 use collab::lock::Mutex;
-use futures_util::SinkExt;
+use futures::SinkExt;
 use tokio::spawn;
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::time::{Instant, Interval};

--- a/collab-user/Cargo.toml
+++ b/collab-user/Cargo.toml
@@ -27,4 +27,4 @@ fs_extra = "1.2.0"
 nanoid = "0.4.0"
 tempfile = "3.8.0"
 tokio = { version = "1.26", features = ["rt", "macros"] }
-uuid = "1.3.3"
+uuid.workspace = true

--- a/collab/Cargo.toml
+++ b/collab/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 yrs.workspace = true
+uuid.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true
 serde = { workspace = true, features = ["rc"] }

--- a/collab/src/core/collab.rs
+++ b/collab/src/core/collab.rs
@@ -345,6 +345,15 @@ impl Collab {
     &self.revisions
   }
 
+  pub fn prune_revisions<F>(&mut self, predicate: F) -> Result<usize, CollabError>
+  where
+    F: Fn(&Revision) -> bool,
+  {
+    let mut txn = self.context.transact_mut();
+    let removed = self.revisions.remove_where(&mut txn, predicate)?;
+    Ok(removed)
+  }
+
   pub fn gc(&mut self) -> Result<(), CollabError> {
     let mut txn = self.context.transact_mut();
     self.revisions.gc(&mut txn)?;

--- a/collab/src/core/collab.rs
+++ b/collab/src/core/collab.rs
@@ -347,7 +347,7 @@ impl Collab {
 
   pub fn prune_revisions<F>(&mut self, predicate: F) -> Result<usize, CollabError>
   where
-    F: Fn(&Revision) -> bool,
+    F: FnMut(&Revision) -> bool,
   {
     let mut txn = self.context.transact_mut();
     let removed = self.revisions.remove_where(&mut txn, predicate)?;

--- a/collab/src/core/collab.rs
+++ b/collab/src/core/collab.rs
@@ -344,8 +344,8 @@ impl Collab {
   pub fn revisions(&self) -> Result<Vec<Revision>, CollabError> {
     let txn = self.context.transact();
     let mut revisions = Vec::new();
-    let mut iter = self.revisions.iter(&txn);
-    while let Some(revision) = iter.next() {
+    let iter = self.revisions.iter(&txn);
+    for revision in iter {
       revisions.push(revision?);
     }
     Ok(revisions)

--- a/collab/src/core/collab.rs
+++ b/collab/src/core/collab.rs
@@ -341,14 +341,8 @@ impl Collab {
     Ok(this)
   }
 
-  pub fn revisions(&self) -> Result<Vec<Revision>, CollabError> {
-    let txn = self.context.transact();
-    let mut revisions = Vec::new();
-    let iter = self.revisions.iter(&txn);
-    for revision in iter {
-      revisions.push(revision?);
-    }
-    Ok(revisions)
+  pub fn revisions(&self) -> &Revisions {
+    &self.revisions
   }
 
   pub fn gc(&mut self) -> Result<(), CollabError> {

--- a/collab/src/core/collab.rs
+++ b/collab/src/core/collab.rs
@@ -351,6 +351,12 @@ impl Collab {
     Ok(revisions)
   }
 
+  pub fn gc(&mut self) -> Result<(), CollabError> {
+    let mut txn = self.context.transact_mut();
+    self.revisions.gc(&mut txn)?;
+    Ok(())
+  }
+
   pub fn revision(&self, revision_id: &RevisionId) -> Result<Revision, CollabError> {
     let txn = self.context.transact();
     self.revisions.get(&txn, revision_id)

--- a/collab/src/core/mod.rs
+++ b/collab/src/core/mod.rs
@@ -5,5 +5,6 @@ mod collab_search;
 pub mod collab_state;
 pub mod fill;
 pub mod origin;
+mod revisions;
 pub mod transaction;
 pub mod value;

--- a/collab/src/core/revisions.rs
+++ b/collab/src/core/revisions.rs
@@ -172,16 +172,14 @@ impl Revisions {
 
     // find the oldest revision to determine the cutoff point for garbage collection
     let mut oldest: Option<Revision> = None;
-    for revision in self.iter(txn) {
-      if let Ok(revision) = revision {
-        match &oldest {
-          None => oldest = Some(revision),
-          Some(oldest_revision) => {
-            if revision.created_at() < oldest_revision.created_at() {
-              oldest = Some(revision);
-            }
-          },
-        }
+    for revision in self.iter(txn).flatten() {
+      match &oldest {
+        None => oldest = Some(revision),
+        Some(oldest_revision) => {
+          if revision.created_at() < oldest_revision.created_at() {
+            oldest = Some(revision);
+          }
+        },
       }
     }
 

--- a/collab/src/core/revisions.rs
+++ b/collab/src/core/revisions.rs
@@ -85,8 +85,8 @@ impl Revisions {
     txn: &T,
     revision_id: &RevisionId,
   ) -> Result<Revision, CollabError> {
-    let mut i = self.iter(txn);
-    while let Some(revision) = i.next() {
+    let i = self.iter(txn);
+    for revision in i {
       let revision = revision?;
       if &revision.id == revision_id {
         return Ok(revision);
@@ -163,7 +163,7 @@ pub struct RevisionsIter<'a, T: ReadTxn> {
   iter: ArrayIter<&'a T, T>,
 }
 
-impl<'a, T: ReadTxn> Iterator for RevisionsIter<'a, T> {
+impl<T: ReadTxn> Iterator for RevisionsIter<'_, T> {
   type Item = Result<Revision, CollabError>;
 
   fn next(&mut self) -> Option<Self::Item> {

--- a/collab/src/core/revisions.rs
+++ b/collab/src/core/revisions.rs
@@ -1,0 +1,181 @@
+use crate::error::CollabError;
+use anyhow::anyhow;
+use serde::{Deserialize, Serialize};
+use uuid::{NoContext, Timestamp, Uuid};
+use yrs::encoding::serde::{from_any, to_any};
+use yrs::types::array::ArrayIter;
+use yrs::updates::decoder::Decode;
+use yrs::updates::encoder::Encode;
+use yrs::{Array, ArrayRef, Out, ReadTxn, Snapshot, TransactionMut};
+
+pub type RevisionId = Uuid;
+
+/// Revision is a record of a collab state at a specific point in time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Revision {
+  id: RevisionId,
+  name: Option<String>,
+  snapshot_state: Vec<u8>,
+}
+
+impl Revision {
+  /// Creates a new [Revision] with the given name and snapshot state.
+  pub fn new(name: Option<String>, snapshot_state: &Snapshot) -> Self {
+    Self {
+      id: RevisionId::new_v7(Timestamp::now(NoContext)),
+      name,
+      snapshot_state: snapshot_state.encode_v1(),
+    }
+  }
+
+  /// Globally unique identifier for the revision.
+  pub fn id(&self) -> &RevisionId {
+    &self.id
+  }
+
+  /// Returns the timestamp when the revision was created.
+  pub fn created_at(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+    let timestamp = self.id.get_timestamp()?;
+    let (seconds, nanos) = timestamp.to_unix();
+    chrono::DateTime::<chrono::Utc>::from_timestamp(seconds as i64, nanos)
+  }
+
+  /// Returns the name of the revision, if it exists.
+  pub fn name(&self) -> Option<&str> {
+    self.name.as_deref()
+  }
+
+  /// Deserializes revision's snapshot state into a yrs [Snapshot].
+  pub fn snapshot(&self) -> Result<Snapshot, CollabError> {
+    Ok(Snapshot::decode_v1(&self.snapshot_state)?)
+  }
+}
+
+pub struct Revisions {
+  revisions: ArrayRef,
+}
+
+impl Revisions {
+  pub fn new(revisions: ArrayRef) -> Self {
+    Self { revisions }
+  }
+
+  pub fn create_revision(
+    &self,
+    txn: &mut TransactionMut,
+    name: Option<String>,
+  ) -> Result<RevisionId, CollabError> {
+    if !txn.doc().skip_gc() {
+      return Err(CollabError::Internal(anyhow!(
+        "revisions cannot be created when garbage collection is enabled"
+      )));
+    }
+
+    let snapshot = txn.snapshot();
+    let revision = Revision::new(name, &snapshot);
+    let encoded_revision = to_any(&revision).map_err(|err| CollabError::Internal(err.into()))?;
+
+    self.revisions.push_back(txn, encoded_revision);
+
+    Ok(revision.id)
+  }
+
+  pub fn get<T: ReadTxn>(
+    &self,
+    txn: &T,
+    revision_id: &RevisionId,
+  ) -> Result<Revision, CollabError> {
+    let mut i = self.iter(txn);
+    while let Some(revision) = i.next() {
+      let revision = revision?;
+      if &revision.id == revision_id {
+        return Ok(revision);
+      }
+    }
+
+    Err(CollabError::NoRequiredData(format!(
+      "Revision '{revision_id}' not found"
+    )))
+  }
+
+  pub fn remove_where<F>(
+    &self,
+    txn: &mut TransactionMut,
+    predicate: F,
+  ) -> Result<usize, CollabError>
+  where
+    F: Fn(&Revision) -> bool,
+  {
+    if !txn.doc().skip_gc() {
+      return Err(CollabError::Internal(anyhow!(
+        "revisions cannot be drained when garbage collection is enabled"
+      )));
+    }
+
+    let mut oldest: Option<Revision> = None;
+    let mut revisions_to_remove = Vec::new();
+    for (index, revision) in self.iter(txn).enumerate() {
+      if let Ok(revision) = revision {
+        if predicate(&revision) {
+          // if the predicate matches, we mark this revision for removal.
+          revisions_to_remove.push(index as u32);
+        } else {
+          // if the predicate does not match, we keep track of the oldest revision for future gc
+          match &oldest {
+            None => oldest = Some(revision),
+            Some(oldest_revision) => {
+              if revision.created_at() < oldest_revision.created_at() {
+                oldest = Some(revision);
+              }
+            },
+          }
+        }
+      }
+    }
+
+    // remove revisions that matched the predicate
+    // use reverse order (last-to-first) to avoid shifting indices
+    let result = revisions_to_remove.len();
+    for index in revisions_to_remove.into_iter().rev() {
+      self.revisions.remove(txn, index);
+    }
+
+    // garbage collect revisions
+    match oldest {
+      Some(oldest_revision) => {
+        // if we have the oldest revision, we can safely gc everything up to that revision
+        let snapshot = oldest_revision.snapshot()?;
+        txn.gc(Some(&snapshot.delete_set));
+      },
+      None => txn.gc(None), // there are no revisions left, we can safely gc everything
+    }
+
+    Ok(result)
+  }
+
+  pub fn iter<'a, T: ReadTxn>(&self, txn: &'a T) -> RevisionsIter<'a, T> {
+    let iter = self.revisions.iter(txn);
+    RevisionsIter { iter }
+  }
+}
+
+pub struct RevisionsIter<'a, T: ReadTxn> {
+  iter: ArrayIter<&'a T, T>,
+}
+
+impl<'a, T: ReadTxn> Iterator for RevisionsIter<'a, T> {
+  type Item = Result<Revision, CollabError>;
+
+  fn next(&mut self) -> Option<Self::Item> {
+    match self.iter.next()? {
+      Out::Any(revision) => {
+        let revision =
+          from_any::<Revision>(&revision).map_err(|err| CollabError::Internal(err.into()));
+        Some(revision)
+      },
+      _ => Some(Err(CollabError::NoRequiredData(
+        "Cannot decode revision".to_string(),
+      ))),
+    }
+  }
+}

--- a/collab/src/core/revisions.rs
+++ b/collab/src/core/revisions.rs
@@ -111,10 +111,10 @@ impl Revisions {
   pub fn remove_where<F>(
     &self,
     txn: &mut TransactionMut,
-    predicate: F,
+    mut predicate: F,
   ) -> Result<usize, CollabError>
   where
-    F: Fn(&Revision) -> bool,
+    F: FnMut(&Revision) -> bool,
   {
     ensure_gc_disabled(txn)?;
 

--- a/collab/src/lock/lock_timeout.rs
+++ b/collab/src/lock/lock_timeout.rs
@@ -153,7 +153,7 @@ mod test {
   #[test]
   fn trait_casting() {
     type CollabRef = Arc<RwLock<dyn BorrowMut<Collab> + Send + Sync + 'static>>;
-    let collab = Arc::new(RwLock::new(Collab::new(0, "test", "device", vec![], false)));
+    let collab = Arc::new(RwLock::new(Collab::new(0, "test", "device", 1)));
     let _collab_ref: CollabRef = collab as CollabRef;
   }
 }

--- a/collab/tests/edit_test/mod.rs
+++ b/collab/tests/edit_test/mod.rs
@@ -2,4 +2,5 @@ mod awareness_test;
 mod insert_test;
 mod observer_test;
 mod restore_test;
+mod revision_test;
 mod state_vec_test;

--- a/collab/tests/edit_test/revision_test.rs
+++ b/collab/tests/edit_test/revision_test.rs
@@ -1,0 +1,74 @@
+use collab::core::collab::{CollabOptions, DataSource, default_client_id};
+use collab::core::origin::CollabOrigin;
+use collab::entity::EncoderVersion;
+use collab::preclude::Collab;
+use serde_json::json;
+use yrs::Update;
+use yrs::updates::decoder::Decode;
+
+#[tokio::test]
+async fn create_restore_revision() {
+  let mut collab = Collab::new(1, "1", "1", default_client_id());
+  collab.insert("key", "value1");
+  let state1 = collab
+    .encode_collab_v1(|_| Ok::<_, anyhow::Error>(()))
+    .unwrap();
+  let state2 = collab.encode_collab_v2();
+  let r1 = collab.create_revision().unwrap();
+  collab.insert("key", "value2");
+
+  // revision is equal to the state before the second insert
+  let restored = collab.restore_revision(&r1, EncoderVersion::V1).unwrap();
+  assert_eq!(restored, state1);
+
+  let restored = collab.restore_revision(&r1, EncoderVersion::V2).unwrap();
+  assert_eq!(restored, state2);
+
+  let restored = Collab::new_with_options(
+    CollabOrigin::Empty,
+    CollabOptions::new("1".into(), default_client_id())
+      .with_data_source(DataSource::DocStateV2(restored.doc_state.into())),
+  )
+  .unwrap();
+
+  // we restored the state before the second insert
+  assert_eq!(restored.to_json_value(), json!({"key": "value1"}));
+}
+
+#[tokio::test]
+async fn remove_revision_cleanups_deleted_data() {
+  let mut collab = Collab::new(1, "1", "1", default_client_id());
+  collab.insert("key", "value1");
+  let r1 = collab.create_named_revision("r1").unwrap();
+  collab.insert("key", "value2");
+  let r2 = collab.create_named_revision("r2").unwrap();
+  collab.insert("key", "value3");
+  let r3 = collab.create_named_revision("r3").unwrap();
+
+  let full_state = collab
+    .encode_collab_v1(|_| Ok::<_, anyhow::Error>(()))
+    .unwrap();
+
+  // removing a middle revision does not clean up the state
+  assert!(collab.remove_revision(&r2).unwrap());
+  let state = collab
+    .encode_collab_v1(|_| Ok::<_, anyhow::Error>(()))
+    .unwrap();
+  assert!(state.doc_state.len() >= full_state.doc_state.len()); // no data was removed
+  assert!(collab.restore_revision(&r2, EncoderVersion::V1).is_err()); // revision no longer exists
+
+  // removing the oldest revision cleans up the state
+  assert!(collab.remove_revision(&r1).unwrap());
+  let state = collab
+    .encode_collab_v1(|_| Ok::<_, anyhow::Error>(()))
+    .unwrap();
+  assert!(state.doc_state.len() < full_state.doc_state.len());
+  assert!(collab.restore_revision(&r1, EncoderVersion::V1).is_err()); // revision no longer exists
+
+  collab.remove_revision(&r3).unwrap();
+  println!(
+    "{:#?} vs {:#?}",
+    Update::decode_v1(&state.doc_state).unwrap(),
+    Update::decode_v1(&full_state.doc_state).unwrap()
+  );
+}

--- a/collab/tests/edit_test/revision_test.rs
+++ b/collab/tests/edit_test/revision_test.rs
@@ -3,8 +3,6 @@ use collab::core::origin::CollabOrigin;
 use collab::entity::EncoderVersion;
 use collab::preclude::Collab;
 use serde_json::json;
-use yrs::Update;
-use yrs::updates::decoder::Decode;
 
 #[tokio::test]
 async fn create_restore_revision() {
@@ -66,9 +64,40 @@ async fn remove_revision_cleanups_deleted_data() {
   assert!(collab.restore_revision(&r1, EncoderVersion::V1).is_err()); // revision no longer exists
 
   collab.remove_revision(&r3).unwrap();
-  println!(
-    "{:#?} vs {:#?}",
-    Update::decode_v1(&state.doc_state).unwrap(),
-    Update::decode_v1(&full_state.doc_state).unwrap()
-  );
+}
+
+#[tokio::test]
+async fn remove_revision_should_eventually_remove_revision_data() {
+  let mut collab = Collab::new(1, "1", "1", default_client_id());
+  collab.insert("key", "value1");
+  let r1 = collab.create_named_revision("revision1").unwrap();
+  collab.insert("key", "value2");
+  let r2 = collab.create_named_revision("revision2").unwrap();
+
+  let state = collab.encode_collab_v2();
+  // initially we should be able to find r1 and r2 keys in the payload
+  assert!(contains(&state.doc_state, "revision1"));
+  assert!(contains(&state.doc_state, "revision2"));
+
+  // removing the first revision should not remove the data immediately,
+  // since r2 was created while r1 was still present
+  collab.remove_revision(&r1).unwrap();
+  let state = collab.encode_collab_v2();
+  assert!(contains(&state.doc_state, "revision1"));
+  assert!(!contains(&state.doc_state, "value1")); // revision is present, but its data is not
+
+  collab.insert("key", "value3");
+  let r3 = collab.create_named_revision("revision3").unwrap();
+
+  // r3 was created after r1 was removed, so it should not contain r1 data
+  // removing r2 should remove the traces of r1 as well
+  collab.remove_revision(&r2).unwrap();
+  let state = collab.encode_collab_v2();
+  assert!(!contains(&state.doc_state, "revision1")); // r1 is finally removed
+  assert!(!contains(&state.doc_state, "value2")); // r2 was removed, so its data is gone
+}
+
+fn contains<P: AsRef<[u8]>>(container: &[u8], key: P) -> bool {
+  let key = key.as_ref();
+  container.windows(key.len()).any(|window| window == key)
 }

--- a/collab/tests/edit_test/revision_test.rs
+++ b/collab/tests/edit_test/revision_test.rs
@@ -87,7 +87,7 @@ async fn remove_revision_should_eventually_remove_revision_data() {
   assert!(!contains(&state.doc_state, "value1")); // revision is present, but its data is not
 
   collab.insert("key", "value3");
-  let r3 = collab.create_named_revision("revision3").unwrap();
+  let _r3 = collab.create_named_revision("revision3").unwrap();
 
   // r3 was created after r1 was removed, so it should not contain r1 data
   // removing r2 should remove the traces of r1 as well

--- a/collab/tests/edit_test/revision_test.rs
+++ b/collab/tests/edit_test/revision_test.rs
@@ -132,7 +132,7 @@ async fn remote_updates_can_be_cleaned_up() {
   c1.insert("key", "value1");
   let r1 = c1.create_named_revision("revision1").unwrap();
   c1.insert("key", "value2");
-  let r2 = c1.create_named_revision("revision2").unwrap();
+  let _r2 = c1.create_named_revision("revision2").unwrap();
   c1.insert("key", "value3");
 
   let mut c2 = Collab::new(1, "1", "2", default_client_id());


### PR DESCRIPTION
This PR adds concept of revisions: "bookmarks" used to timestamp collab state into specific point in time.


This PR heavy relies on document having its garbage collection turned off, since this is what yrs Snapshots require. However garbage is not bound to be kept forever, since removing outdated revisions can trigger garbage collection for data that is no longer used by any revision.