### PR TITLE
chore: change view id type from String to Arc<str>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,6 +610,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "assert-json-diff",
+ "async-trait",
  "chrono",
  "collab",
  "collab-entity",

--- a/collab-folder/Cargo.toml
+++ b/collab-folder/Cargo.toml
@@ -22,6 +22,7 @@ tracing.workspace = true
 dashmap = "5"
 arc-swap = "1.7"
 uuid.workspace = true
+async-trait.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/collab-folder/src/entities.rs
+++ b/collab-folder/src/entities.rs
@@ -1,12 +1,12 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{SectionsByUid, View, Workspace};
+use crate::{SectionsByUid, View, ViewId, Workspace};
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct FolderData {
   pub uid: i64,
   pub workspace: Workspace,
-  pub current_view: String,
+  pub current_view: ViewId,
   pub views: Vec<View>,
   #[serde(default)]
   pub favorites: SectionsByUid,
@@ -23,7 +23,7 @@ impl FolderData {
     Self {
       uid,
       workspace,
-      current_view: "".to_string(),
+      current_view: "".into(),
       views: vec![],
       favorites: SectionsByUid::new(),
       recent: SectionsByUid::new(),
@@ -35,7 +35,7 @@ impl FolderData {
 
 #[derive(Clone, Debug)]
 pub struct TrashInfo {
-  pub id: String,
+  pub id: ViewId,
   pub name: String,
   pub created_at: i64,
 }

--- a/collab-folder/src/folder.rs
+++ b/collab-folder/src/folder.rs
@@ -343,7 +343,7 @@ impl Folder {
     }
   }
 
-  pub fn replace_view(&mut self, from: &str, to: &str, uid: i64) -> bool {
+  pub fn replace_view(&mut self, from: &ViewId, to: &ViewId, uid: i64) -> bool {
     let mut txn = self.collab.transact_mut();
     self.body.replace_view(&mut txn, from, to, uid)
   }
@@ -811,8 +811,8 @@ impl FolderBody {
   pub fn replace_view(
     &self,
     txn: &mut TransactionMut,
-    old_view_id: &str,
-    new_view_id: &str,
+    old_view_id: &ViewId,
+    new_view_id: &ViewId,
     uid: i64,
   ) -> bool {
     self.views.replace_view(txn, old_view_id, new_view_id, uid)

--- a/collab-folder/src/folder.rs
+++ b/collab-folder/src/folder.rs
@@ -19,7 +19,7 @@ use crate::revision::RevisionMapping;
 use crate::section::{Section, SectionItem, SectionMap};
 use crate::{
   FolderData, ParentChildRelations, SectionChangeSender, SpacePermission, TrashInfo, View,
-  ViewChangeReceiver, ViewUpdate, ViewsMap, Workspace, impl_section_op,
+  ViewChangeReceiver, ViewId, ViewUpdate, ViewsMap, Workspace, impl_section_op,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
@@ -215,7 +215,7 @@ impl Folder {
     &mut self,
     view_id: &str,
     new_parent_id: &str,
-    prev_view_id: Option<String>,
+    prev_view_id: Option<ViewId>,
     uid: i64,
   ) -> Option<Arc<View>> {
     let mut txn = self.collab.transact_mut();
@@ -224,12 +224,12 @@ impl Folder {
       .move_nested_view(&mut txn, view_id, new_parent_id, prev_view_id, uid)
   }
 
-  pub fn set_current_view(&mut self, view_id: String, uid: i64) {
+  pub fn set_current_view(&mut self, view_id: ViewId, uid: i64) {
     let mut txn = self.collab.transact_mut();
     self.body.set_current_view(&mut txn, view_id, uid);
   }
 
-  pub fn get_current_view(&self, uid: i64) -> Option<String> {
+  pub fn get_current_view(&self, uid: i64) -> Option<ViewId> {
     let txn = self.collab.transact();
     self.body.get_current_view(&txn, uid)
   }
@@ -715,13 +715,13 @@ impl FolderBody {
     txn: &mut TransactionMut,
     view_id: &str,
     new_parent_id: &str,
-    prev_view_id: Option<String>,
+    prev_view_id: Option<ViewId>,
     uid: i64,
   ) -> Option<Arc<View>> {
     tracing::debug!("Move nested view: {}", view_id);
     let view = self.views.get_view_with_txn(txn, view_id, uid)?;
     let current_workspace_id = self.get_workspace_id_with_txn(txn)?;
-    let parent_id = view.parent_view_id.as_str();
+    let parent_id = view.parent_view_id.as_ref();
 
     let new_parent_view = self.views.get_view_with_txn(txn, new_parent_id, uid);
 
@@ -740,7 +740,7 @@ impl FolderBody {
     // place it as the first child.
     self
       .views
-      .associate_parent_child_with_txn(txn, new_parent_id, view_id, prev_view_id.clone());
+      .associate_parent_child_with_txn(txn, new_parent_id, view_id, prev_view_id);
     // Update the view's parent ID.
     self
       .views
@@ -750,7 +750,7 @@ impl FolderBody {
     Some(view)
   }
 
-  pub fn get_child_of_first_public_view<T: ReadTxn>(&self, txn: &T, uid: i64) -> Option<String> {
+  pub fn get_child_of_first_public_view<T: ReadTxn>(&self, txn: &T, uid: i64) -> Option<ViewId> {
     self
       .get_workspace_id(txn)
       .and_then(|workspace_id| self.views.get_view(txn, &workspace_id, uid))
@@ -784,7 +784,7 @@ impl FolderBody {
       })
   }
 
-  pub fn get_current_view<T: ReadTxn>(&self, txn: &T, uid: i64) -> Option<String> {
+  pub fn get_current_view<T: ReadTxn>(&self, txn: &T, uid: i64) -> Option<ViewId> {
     // Fallback to CURRENT_VIEW if CURRENT_VIEW_FOR_USER is not present. This could happen for
     // workspace folder created by older version of the app before CURRENT_VIEW_FOR_USER is introduced.
     // If user cannot be found in CURRENT_VIEW_FOR_USER, use the first child of the first public space
@@ -795,7 +795,7 @@ impl FolderBody {
     };
     match current_view_for_user_map {
       Some(current_view_for_user) => {
-        let view_for_user: Option<String> =
+        let view_for_user: Option<ViewId> =
           current_view_for_user.get_with_txn(txn, uid.to_string().as_ref());
         view_for_user.or(self.get_child_of_first_public_view(txn, uid))
       },
@@ -803,7 +803,7 @@ impl FolderBody {
     }
   }
 
-  pub fn set_current_view(&self, txn: &mut TransactionMut, view: String, uid: i64) {
+  pub fn set_current_view(&self, txn: &mut TransactionMut, view: ViewId, uid: i64) {
     let current_view_for_user = self.meta.get_or_init_map(txn, CURRENT_VIEW_FOR_USER);
     current_view_for_user.try_update(txn, uid.to_string(), view);
   }
@@ -821,7 +821,7 @@ impl FolderBody {
 
 pub fn default_folder_data(uid: i64, workspace_id: &str) -> FolderData {
   let workspace = Workspace {
-    id: workspace_id.to_string(),
+    id: workspace_id.into(),
     name: "".to_string(),
     child_views: Default::default(),
     created_at: 0,
@@ -832,7 +832,7 @@ pub fn default_folder_data(uid: i64, workspace_id: &str) -> FolderData {
   FolderData {
     uid,
     workspace,
-    current_view: "".to_string(),
+    current_view: "".into(),
     views: vec![],
     favorites: HashMap::new(),
     recent: HashMap::new(),
@@ -846,7 +846,7 @@ mod tests {
   use std::collections::HashMap;
 
   use crate::{
-    Folder, FolderData, RepeatedViewIdentifier, SectionItem, SpaceInfo, UserId, View,
+    Folder, FolderData, RepeatedViewIdentifier, SectionItem, SpaceInfo, UserId, View, ViewId,
     ViewIdentifier, Workspace,
   };
   use collab::core::collab::default_client_id;
@@ -860,25 +860,25 @@ mod tests {
     let options = CollabOptions::new(workspace_id.to_string(), default_client_id());
     let collab = Collab::new_with_options(CollabOrigin::Empty, options).unwrap();
     let view_1 = View::new(
-      "view_1".to_string(),
-      workspace_id.to_string(),
-      "View 1".to_string(),
+      "view_1".into(),
+      workspace_id.into(),
+      "View 1".into(),
       crate::ViewLayout::Document,
       Some(uid),
     );
     let view_1_id = view_1.id.clone();
     let view_2 = View::new(
-      "view_2".to_string(),
-      workspace_id.to_string(),
-      "View 2".to_string(),
+      "view_2".into(),
+      workspace_id.into(),
+      "View 2".into(),
       crate::ViewLayout::Document,
       Some(uid),
     );
     let view_2_id = view_2.id.clone();
     let space_view = View {
-      id: "space_1_id".to_string(),
-      parent_view_id: workspace_id.to_string(),
-      name: "Space 1".to_string(),
+      id: "space_1_id".into(),
+      parent_view_id: workspace_id.into(),
+      name: "Space 1".into(),
       children: RepeatedViewIdentifier::new(vec![
         ViewIdentifier::new(view_1_id.clone()),
         ViewIdentifier::new(view_2_id.clone()),
@@ -895,7 +895,7 @@ mod tests {
     };
     let space_view_id = space_view.id.clone();
     let workspace = Workspace {
-      id: workspace_id.to_string(),
+      id: workspace_id.into(),
       name: "Workspace".to_string(),
       child_views: RepeatedViewIdentifier::new(vec![ViewIdentifier::new(space_view_id.clone())]),
       created_at: current_time,
@@ -916,12 +916,12 @@ mod tests {
     let mut folder = Folder::create(collab, None, folder_data);
 
     folder.set_current_view(view_2_id.clone(), uid);
-    assert_eq!(folder.get_current_view(uid), Some(view_2_id.to_string()));
+    assert_eq!(folder.get_current_view(uid), Some(view_2_id.clone()));
     // First visit from user 2, should return the first child of the first public space with children.
-    assert_eq!(folder.get_current_view(2), Some(view_1_id.to_string()));
-    folder.set_current_view(view_1_id.to_string(), 2);
-    assert_eq!(folder.get_current_view(1), Some(view_2_id.to_string()));
-    assert_eq!(folder.get_current_view(2), Some(view_1_id.to_string()));
+    assert_eq!(folder.get_current_view(2), Some(view_1_id.clone()));
+    folder.set_current_view(view_1_id.clone(), 2);
+    assert_eq!(folder.get_current_view(1), Some(view_2_id));
+    assert_eq!(folder.get_current_view(2), Some(view_1_id));
   }
 
   #[test]
@@ -931,11 +931,11 @@ mod tests {
     let uid = 1;
     let options = CollabOptions::new(workspace_id.to_string(), default_client_id());
     let collab = Collab::new_with_options(CollabOrigin::Empty, options).unwrap();
-    let space_view_id = "space_view_id".to_string();
+    let space_view_id: ViewId = "space_view_id".into();
     let views: Vec<View> = (0..3)
       .map(|i| {
         View::new(
-          format!("view_{:?}", i),
+          format!("view_{:?}", i).into(),
           space_view_id.clone(),
           format!("View {:?}", i),
           crate::ViewLayout::Document,
@@ -944,9 +944,9 @@ mod tests {
       })
       .collect();
     let space_view = View {
-      id: "space_1_id".to_string(),
-      parent_view_id: workspace_id.to_string(),
-      name: "Space 1".to_string(),
+      id: "space_1_id".into(),
+      parent_view_id: workspace_id.into(),
+      name: "Space 1".into(),
       children: RepeatedViewIdentifier::new(
         views
           .iter()
@@ -964,7 +964,7 @@ mod tests {
       extra: Some(serde_json::to_string(&SpaceInfo::default()).unwrap()),
     };
     let workspace = Workspace {
-      id: workspace_id.to_string(),
+      id: workspace_id.into(),
       name: "Workspace".to_string(),
       child_views: RepeatedViewIdentifier::new(vec![ViewIdentifier::new(space_view_id.clone())]),
       created_at: current_time,
@@ -996,25 +996,25 @@ mod tests {
     let mut folder = Folder::create(collab, None, folder_data);
     let favorite_sections = folder.get_all_favorites_sections(uid);
     let expected_favorites = vec![
-      SectionItem::new("view_0".to_string()),
-      SectionItem::new("view_1".to_string()),
-      SectionItem::new("view_2".to_string()),
+      SectionItem::new("view_0".into()),
+      SectionItem::new("view_1".into()),
+      SectionItem::new("view_2".into()),
     ];
     assert_eq!(favorite_sections, expected_favorites);
     folder.move_favorite_view_id("view_0", Some("view_1"), uid);
     let favorite_sections = folder.get_all_favorites_sections(uid);
     let expected_favorites = vec![
-      SectionItem::new("view_1".to_string()),
-      SectionItem::new("view_0".to_string()),
-      SectionItem::new("view_2".to_string()),
+      SectionItem::new("view_1".into()),
+      SectionItem::new("view_0".into()),
+      SectionItem::new("view_2".into()),
     ];
     assert_eq!(favorite_sections, expected_favorites);
     folder.move_favorite_view_id("view_2", None, uid);
     let favorite_sections = folder.get_all_favorites_sections(uid);
     let expected_favorites = vec![
-      SectionItem::new("view_2".to_string()),
-      SectionItem::new("view_1".to_string()),
-      SectionItem::new("view_0".to_string()),
+      SectionItem::new("view_2".into()),
+      SectionItem::new("view_1".into()),
+      SectionItem::new("view_0".into()),
     ];
     assert_eq!(favorite_sections, expected_favorites);
   }

--- a/collab-folder/src/folder_migration.rs
+++ b/collab-folder/src/folder_migration.rs
@@ -3,7 +3,7 @@ use collab::preclude::{Any, Array, ArrayRef, Map, MapExt, MapRef, ReadTxn, YrsVa
 use serde::{Deserialize, Serialize};
 
 use crate::folder::FAVORITES_V1;
-use crate::{Folder, ParentChildRelations, SectionItem, Workspace};
+use crate::{Folder, ParentChildRelations, SectionItem, ViewId, Workspace};
 
 const WORKSPACE_ID: &str = "id";
 const WORKSPACE_NAME: &str = "name";
@@ -62,7 +62,7 @@ pub fn to_workspace_with_txn<T: ReadTxn>(
   map_ref: &MapRef,
   views: &ParentChildRelations,
 ) -> Option<Workspace> {
-  let id: String = map_ref.get_with_txn(txn, WORKSPACE_ID)?;
+  let id: ViewId = map_ref.get_with_txn(txn, WORKSPACE_ID)?;
   let name = map_ref
     .get_with_txn(txn, WORKSPACE_NAME)
     .unwrap_or_default();
@@ -120,7 +120,7 @@ impl TryFrom<&YrsValue> for FavoriteId {
 
 #[derive(Debug, Serialize, Deserialize)]
 struct TrashRecord {
-  pub id: String,
+  pub id: ViewId,
   #[serde(deserialize_with = "collab::preclude::deserialize_i64_from_numeric")]
   pub created_at: i64,
   #[serde(default)]

--- a/collab-folder/src/folder_observe.rs
+++ b/collab-folder/src/folder_observe.rs
@@ -9,7 +9,7 @@ use tokio::sync::broadcast;
 use crate::revision::RevisionMapping;
 use crate::section::SectionMap;
 use crate::view::FOLDER_VIEW_ID;
-use crate::{ParentChildRelations, ViewId, View, view_from_map_ref};
+use crate::{ParentChildRelations, View, ViewId, view_from_map_ref};
 
 #[derive(Debug, Clone)]
 pub enum ViewChange {

--- a/collab-folder/src/folder_observe.rs
+++ b/collab-folder/src/folder_observe.rs
@@ -9,7 +9,7 @@ use tokio::sync::broadcast;
 use crate::revision::RevisionMapping;
 use crate::section::SectionMap;
 use crate::view::FOLDER_VIEW_ID;
-use crate::{ParentChildRelations, View, view_from_map_ref};
+use crate::{ParentChildRelations, ViewId, View, view_from_map_ref};
 
 #[derive(Debug, Clone)]
 pub enum ViewChange {
@@ -23,7 +23,7 @@ pub type ViewChangeReceiver = broadcast::Receiver<ViewChange>;
 
 pub(crate) fn subscribe_view_change(
   root: &MapRef,
-  deletion_cache: Arc<DashMap<String, Arc<View>>>,
+  deletion_cache: Arc<DashMap<ViewId, Arc<View>>>,
   change_tx: ViewChangeSender,
   view_relations: Arc<ParentChildRelations>,
   section_map: Arc<SectionMap>,

--- a/collab-folder/src/hierarchy_builder.rs
+++ b/collab-folder/src/hierarchy_builder.rs
@@ -1,8 +1,8 @@
 use crate::space_info::SpacePermission;
 use crate::{
   IconType, RepeatedViewIdentifier, SPACE_CREATED_AT_KEY, SPACE_ICON_COLOR_KEY, SPACE_ICON_KEY,
-  SPACE_IS_SPACE_KEY, SPACE_PERMISSION_KEY, SpaceInfo, View, ViewIcon, ViewIdentifier, ViewLayout,
-  timestamp,
+  SPACE_IS_SPACE_KEY, SPACE_PERMISSION_KEY, SpaceInfo, View, ViewIcon, ViewId, ViewIdentifier,
+  ViewLayout, timestamp,
 };
 
 use serde_json::json;
@@ -14,12 +14,12 @@ use std::ops::{Deref, DerefMut};
 /// The views created by this builder will be the first level views of the workspace.
 pub struct NestedViewBuilder {
   pub uid: i64,
-  pub workspace_id: String,
+  pub workspace_id: ViewId,
   pub views: Vec<ParentChildViews>,
 }
 
 impl NestedViewBuilder {
-  pub fn new(workspace_id: String, uid: i64) -> Self {
+  pub fn new(workspace_id: ViewId, uid: i64) -> Self {
     Self {
       uid,
       workspace_id,
@@ -67,7 +67,7 @@ impl NestedViews {
   pub fn remove_view(&mut self, view_id: &str) {
     // recursively remove the view and its children views.
     self.views.retain_mut(|view| {
-      if view.view.id == view_id {
+      if view.view.id.as_ref() == view_id {
         return false;
       }
       view.remove_view(view_id);
@@ -108,8 +108,8 @@ impl DerefMut for NestedViews {
 /// The default layout of the view is [ViewLayout::Document]
 pub struct NestedChildViewBuilder {
   uid: i64,
-  parent_view_id: String,
-  view_id: String,
+  parent_view_id: ViewId,
+  view_id: ViewId,
   name: String,
   desc: String,
   layout: ViewLayout,
@@ -123,11 +123,11 @@ pub struct NestedChildViewBuilder {
 impl NestedChildViewBuilder {
   /// Create a new view builder.
   /// It generates a new view id for the view. If you want to specify the view id, you can use [with_view_id] method.
-  pub fn new(uid: i64, parent_view_id: String) -> Self {
+  pub fn new(uid: i64, parent_view_id: ViewId) -> Self {
     Self {
       uid,
       parent_view_id,
-      view_id: uuid::Uuid::new_v4().to_string(),
+      view_id: uuid::Uuid::new_v4().to_string().into(),
       name: Default::default(),
       desc: Default::default(),
       layout: ViewLayout::Document,
@@ -153,8 +153,8 @@ impl NestedChildViewBuilder {
     self
   }
 
-  pub fn with_view_id<T: ToString>(mut self, view_id: T) -> Self {
-    self.view_id = view_id.to_string();
+  pub fn with_view_id<T: Into<ViewId>>(mut self, view_id: T) -> Self {
+    self.view_id = view_id.into();
     self
   }
 
@@ -321,7 +321,7 @@ impl Display for ParentChildViews {
 impl ParentChildViews {
   pub fn remove_view(&mut self, view_id: &str) {
     self.children.retain_mut(|child_view| {
-      if child_view.view.id == view_id {
+      if child_view.view.id.as_ref() == view_id {
         return false;
       }
       child_view.remove_view(view_id);
@@ -330,7 +330,7 @@ impl ParentChildViews {
   }
 
   pub fn find_view(&self, view_id: &str) -> Option<&View> {
-    if self.view.id == view_id {
+    if self.view.id.as_ref() == view_id {
       return Some(&self.view);
     }
     for child_view in &self.children {
@@ -358,11 +358,12 @@ impl FlattedViews {
 
 #[cfg(test)]
 mod tests {
+  use crate::ViewId;
   use crate::hierarchy_builder::{FlattedViews, NestedViewBuilder};
 
   #[tokio::test]
   async fn create_first_level_views_test() {
-    let workspace_id = "w1".to_string();
+    let workspace_id: ViewId = "w1".into();
     let mut builder = NestedViewBuilder::new(workspace_id, 1);
     builder
       .with_view_builder(|view_builder| async { view_builder.with_name("1").build() })
@@ -382,7 +383,7 @@ mod tests {
 
   #[tokio::test]
   async fn create_view_with_children_test() {
-    let workspace_id = "w1".to_string();
+    let workspace_id: ViewId = "w1".into();
     let mut builder = NestedViewBuilder::new(workspace_id, 1);
     builder
       .with_view_builder(|view_builder| async {
@@ -441,7 +442,7 @@ mod tests {
 
   #[tokio::test]
   async fn create_three_level_view_test() {
-    let workspace_id = "w1".to_string();
+    let workspace_id: ViewId = "w1".into();
     let mut builder = NestedViewBuilder::new(workspace_id, 1);
     builder
       .with_view_builder(|view_builder| async {
@@ -515,7 +516,7 @@ mod tests {
 
   #[tokio::test]
   async fn delete_multiple_views_in_sequence_test() {
-    let workspace_id = "w1".to_string();
+    let workspace_id: ViewId = "w1".into();
     let mut builder = NestedViewBuilder::new(workspace_id, 1);
 
     // Create a 3-level nested view hierarchy

--- a/collab-folder/src/view.rs
+++ b/collab-folder/src/view.rs
@@ -43,7 +43,7 @@ pub struct ViewsMap {
   pub(crate) section_map: Arc<SectionMap>,
   pub(crate) revision_map: Arc<RevisionMapping>,
   // Minimal cache only for deletion notifications - stores basic view info
-  deletion_cache: Arc<DashMap<String, Arc<View>>>,
+  deletion_cache: Arc<DashMap<ViewId, Arc<View>>>,
   subscription: Mutex<Option<Subscription>>,
   change_tx: Option<ViewChangeSender>,
 }
@@ -69,7 +69,7 @@ impl ViewsMap {
     }
   }
 
-  pub async fn observe_view_change(&self, uid: i64, views: HashMap<String, Arc<View>>) {
+  pub async fn observe_view_change(&self, uid: i64, views: HashMap<ViewId, Arc<View>>) {
     for (k, v) in views {
       self.deletion_cache.insert(k, v);
     }
@@ -110,7 +110,7 @@ impl ViewsMap {
     txn: &mut TransactionMut,
     parent_id: &str,
     view_id: &str,
-    prev_id: Option<String>,
+    prev_id: Option<ViewId>,
   ) {
     self.associate_parent_child_with_txn(txn, parent_id, view_id, prev_id);
   }
@@ -131,7 +131,7 @@ impl ViewsMap {
     txn: &mut TransactionMut,
     parent_id: &str,
     view_id: &str,
-    prev_view_id: Option<String>,
+    prev_view_id: Option<ViewId>,
   ) {
     self
       .parent_children_relation
@@ -188,7 +188,7 @@ impl ViewsMap {
               .into_inner()
               .into_iter()
               .map(|identifier| identifier.id)
-              .collect::<Vec<String>>()
+              .collect::<Vec<_>>()
           })
           .unwrap_or_default();
 
@@ -499,8 +499,8 @@ pub(crate) fn view_from_map_ref<T: ReadTxn>(
   uid: i64,
   mappings: impl IntoIterator<Item = String>,
 ) -> Option<View> {
-  let parent_view_id: String = map_ref.get_with_txn(txn, VIEW_PARENT_ID)?;
-  let id: String = map_ref.get_with_txn(txn, FOLDER_VIEW_ID)?;
+  let parent_view_id: ViewId = map_ref.get_with_txn(txn, VIEW_PARENT_ID)?;
+  let id: ViewId = map_ref.get_with_txn(txn, FOLDER_VIEW_ID)?;
   let name: String = map_ref
     .get_with_txn(txn, FOLDER_VIEW_NAME)
     .unwrap_or_default();
@@ -687,8 +687,7 @@ impl<'a, 'b, 'c> ViewUpdate<'a, 'b, 'c> {
         .section_op(self.txn, Section::Private, self.uid.as_i64())
     {
       if is_private {
-        private_section
-          .add_sections_item(self.txn, vec![SectionItem::new(self.view_id.to_string())]);
+        private_section.add_sections_item(self.txn, vec![SectionItem::new(self.view_id.into())]);
       } else {
         private_section.delete_section_items_with_txn(self.txn, vec![self.view_id.to_string()]);
       }
@@ -704,7 +703,7 @@ impl<'a, 'b, 'c> ViewUpdate<'a, 'b, 'c> {
         .section_op(self.txn, Section::Favorite, self.uid.as_i64())
     {
       if is_favorite {
-        fav_section.add_sections_item(self.txn, vec![SectionItem::new(self.view_id.to_string())]);
+        fav_section.add_sections_item(self.txn, vec![SectionItem::new(self.view_id.into())]);
       } else {
         fav_section.delete_section_items_with_txn(self.txn, vec![self.view_id.to_string()]);
       }
@@ -728,7 +727,7 @@ impl<'a, 'b, 'c> ViewUpdate<'a, 'b, 'c> {
         .section_op(self.txn, Section::Trash, self.uid.as_i64())
     {
       if is_trash {
-        trash_section.add_sections_item(self.txn, vec![SectionItem::new(self.view_id.to_string())]);
+        trash_section.add_sections_item(self.txn, vec![SectionItem::new(self.view_id.into())]);
       } else {
         trash_section.delete_section_items_with_txn(self.txn, vec![self.view_id.to_string()]);
       }
@@ -761,12 +760,14 @@ impl<'a, 'b, 'c> ViewUpdate<'a, 'b, 'c> {
   }
 }
 
+pub type ViewId = Arc<str>;
+
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct View {
   /// The id of the view
-  pub id: String,
+  pub id: ViewId,
   /// The id for given parent view
-  pub parent_view_id: String,
+  pub parent_view_id: ViewId,
   /// The name that display on the left sidebar
   pub name: String,
   /// A list of ids, each of them is the id of other view
@@ -796,8 +797,8 @@ pub struct View {
 
 impl View {
   pub fn new(
-    view_id: String,
-    parent_view_id: String,
+    view_id: ViewId,
+    parent_view_id: ViewId,
     name: String,
     layout: ViewLayout,
     created_by: Option<i64>,
@@ -819,23 +820,6 @@ impl View {
     }
   }
 
-  pub fn orphan_view(view_id: &str, layout: ViewLayout, uid: Option<i64>) -> Self {
-    View {
-      id: view_id.to_string(),
-      parent_view_id: view_id.to_string(),
-      name: "".to_string(),
-      children: Default::default(),
-      created_at: timestamp(),
-      is_favorite: false,
-      layout,
-      icon: None,
-      created_by: uid,
-      last_edited_time: 0,
-      last_edited_by: None,
-      is_locked: None,
-      extra: None,
-    }
-  }
   pub fn space_info(&self) -> Option<SpaceInfo> {
     let extra = self.extra.as_ref()?;
     serde_json::from_str::<SpaceInfo>(extra).ok()

--- a/collab-folder/src/view.rs
+++ b/collab-folder/src/view.rs
@@ -224,7 +224,7 @@ impl ViewsMap {
       .collect();
 
     for view_id in roots {
-      let (_, mappings) = self.revision_map.mappings(txn, view_id.to_string());
+      let (_, mappings) = self.revision_map.mappings(txn, view_id.into());
       let values = mapped
         .entry(view_id.to_string())
         .or_insert_with(HashSet::new);
@@ -468,13 +468,13 @@ impl ViewsMap {
   pub fn replace_view(
     &self,
     txn: &mut TransactionMut,
-    old_view_id: &str,
-    new_view_id: &str,
+    old_view_id: &ViewId,
+    new_view_id: &ViewId,
     uid: i64,
   ) -> bool {
     if let Some(old_view) = self.get_view(txn, old_view_id, uid) {
       let mut new_view = (*old_view).clone();
-      new_view.id = new_view_id.to_string();
+      new_view.id = new_view_id.clone();
       new_view.last_edited_by = Some(uid);
       new_view.last_edited_time = timestamp();
 
@@ -497,7 +497,7 @@ pub(crate) fn view_from_map_ref<T: ReadTxn>(
   view_relations: &Arc<ParentChildRelations>,
   section_map: &SectionMap,
   uid: i64,
-  mappings: impl IntoIterator<Item = String>,
+  mappings: impl IntoIterator<Item = ViewId>,
 ) -> Option<View> {
   let parent_view_id: ViewId = map_ref.get_with_txn(txn, VIEW_PARENT_ID)?;
   let id: ViewId = map_ref.get_with_txn(txn, FOLDER_VIEW_ID)?;

--- a/collab-folder/src/workspace.rs
+++ b/collab-folder/src/workspace.rs
@@ -1,10 +1,10 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{RepeatedViewIdentifier, View, ViewLayout, timestamp};
+use crate::{RepeatedViewIdentifier, View, ViewId, ViewLayout, timestamp};
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Workspace {
-  pub id: String,
+  pub id: ViewId,
   pub name: String,
   pub child_views: RepeatedViewIdentifier,
   pub created_at: i64,
@@ -14,7 +14,7 @@ pub struct Workspace {
 }
 
 impl Workspace {
-  pub fn new(id: String, name: String, uid: i64) -> Self {
+  pub fn new(id: ViewId, name: String, uid: i64) -> Self {
     debug_assert!(!id.is_empty());
     let time = timestamp();
     Self {
@@ -46,7 +46,7 @@ impl From<Workspace> for View {
   fn from(value: Workspace) -> Self {
     Self {
       id: value.id,
-      parent_view_id: "".to_string(),
+      parent_view_id: "".into(),
       name: value.name,
       children: value.child_views,
       created_at: value.created_at,

--- a/collab-folder/tests/folder_test/child_views_test.rs
+++ b/collab-folder/tests/folder_test/child_views_test.rs
@@ -180,11 +180,7 @@ fn move_child_views_test() {
   let v_1_1 = make_test_view("1_1", "1", vec![]);
   let v_1_2 = make_test_view("1_2", "1", vec![]);
   let v_1_3 = make_test_view("1_3", "1", vec![]);
-  let v_1 = make_test_view(
-    "1",
-    "w1",
-    vec!["1_1".to_string(), "1_2".to_string(), "1_3".to_string()],
-  );
+  let v_1 = make_test_view("1", "w1", vec!["1_1".into(), "1_2".into(), "1_3".into()]);
 
   let mut folder = folder_test.folder;
   let mut txn = folder.collab.transact_mut();
@@ -210,9 +206,9 @@ fn move_child_views_test() {
     .body
     .views
     .get_views_belong_to(&txn, &v_1.id, uid.as_i64());
-  assert_eq!(v_1_child_views[0].id, "1_1");
-  assert_eq!(v_1_child_views[1].id, "1_2");
-  assert_eq!(v_1_child_views[2].id, "1_3");
+  assert_eq!(&*v_1_child_views[0].id, "1_1");
+  assert_eq!(&*v_1_child_views[1].id, "1_2");
+  assert_eq!(&*v_1_child_views[2].id, "1_3");
 
   folder.body.views.move_child(&mut txn, &v_1.id, 2, 0);
   folder.body.views.move_child(&mut txn, &v_1.id, 0, 1);
@@ -222,9 +218,9 @@ fn move_child_views_test() {
     .views
     .get_view(&txn, &v_1.id, uid.as_i64())
     .unwrap();
-  assert_eq!(v_1_child_views.children[0].id, "1_1");
-  assert_eq!(v_1_child_views.children[1].id, "1_3");
-  assert_eq!(v_1_child_views.children[2].id, "1_2");
+  assert_eq!(&*v_1_child_views.children[0].id, "1_1");
+  assert_eq!(&*v_1_child_views.children[1].id, "1_3");
+  assert_eq!(&*v_1_child_views.children[2].id, "1_2");
 }
 
 #[test]
@@ -256,8 +252,8 @@ fn delete_view_test() {
     .body
     .views
     .get_views_belong_to(&txn, "w1", uid.as_i64());
-  assert_eq!(w_1_child_views[0].id, "1_1");
-  assert_eq!(w_1_child_views[1].id, "1_3");
+  assert_eq!(&*w_1_child_views[0].id, "1_1");
+  assert_eq!(&*w_1_child_views[1].id, "1_3");
 }
 
 #[test]

--- a/collab-folder/tests/folder_test/custom_section.rs
+++ b/collab-folder/tests/folder_test/custom_section.rs
@@ -21,7 +21,7 @@ fn custom_section_test() {
     .section
     .section_op(&txn, Section::Favorite, uid.as_i64())
     .unwrap();
-  op.add_sections_item(&mut txn, vec![SectionItem::new("1".to_string())]);
+  op.add_sections_item(&mut txn, vec![SectionItem::new("1".into())]);
 
   let _ = folder
     .body
@@ -32,7 +32,7 @@ fn custom_section_test() {
     .section
     .section_op(&txn, Section::Custom("private".to_string()), uid.as_i64())
     .unwrap();
-  op.add_sections_item(&mut txn, vec![SectionItem::new("2".to_string())]);
+  op.add_sections_item(&mut txn, vec![SectionItem::new("2".into())]);
 
   drop(txn);
 

--- a/collab-folder/tests/folder_test/favorite_test.rs
+++ b/collab-folder/tests/folder_test/favorite_test.rs
@@ -34,10 +34,10 @@ fn create_favorite_test() {
       .views
       .get_views_belong_to(&folder.collab.transact(), &workspace_id, uid.as_i64());
   assert_eq!(views.len(), 2);
-  assert_eq!(views[0].id, "1");
+  assert_eq!(&*views[0].id, "1");
   assert!(views[0].is_favorite);
 
-  assert_eq!(views[1].id, "2");
+  assert_eq!(&*views[1].id, "2");
   assert!(!views[1].is_favorite);
 
   let favorites = folder.get_my_favorite_sections(uid.as_i64());
@@ -63,7 +63,7 @@ fn add_favorite_view_and_then_remove_test() {
       .views
       .get_views_belong_to(&folder.transact(), &workspace_id, uid.as_i64());
   assert_eq!(views.len(), 1);
-  assert_eq!(views[0].id, "1");
+  assert_eq!(&*views[0].id, "1");
   assert!(views[0].is_favorite);
 
   folder.delete_favorite_view_ids(vec!["1".to_string()], uid.as_i64());
@@ -94,8 +94,8 @@ fn create_multiple_user_favorite_test() {
   folder_1.add_favorite_view_ids(vec!["1".to_string(), "2".to_string()], uid_1.as_i64());
   let favorites = folder_1.get_my_favorite_sections(uid_1.as_i64());
   assert_eq!(favorites.len(), 2);
-  assert_eq!(favorites[0].id, "1");
-  assert_eq!(favorites[1].id, "2");
+  assert_eq!(&*favorites[0].id, "1");
+  assert_eq!(&*favorites[1].id, "2");
   let folder_data = folder_1
     .get_folder_data(&workspace_id, uid_1.as_i64())
     .unwrap();
@@ -181,13 +181,13 @@ fn delete_favorite_test() {
 
   let favorites = folder.get_my_favorite_sections(uid.as_i64());
   assert_eq!(favorites.len(), 2);
-  assert_eq!(favorites[0].id, "1");
-  assert_eq!(favorites[1].id, "2");
+  assert_eq!(&*favorites[0].id, "1");
+  assert_eq!(&*favorites[1].id, "2");
 
   folder.delete_favorite_view_ids(vec!["1".to_string()], uid.as_i64());
   let favorites = folder.get_my_favorite_sections(uid.as_i64());
   assert_eq!(favorites.len(), 1);
-  assert_eq!(favorites[0].id, "2");
+  assert_eq!(&*favorites[0].id, "2");
 
   folder.remove_all_my_favorite_sections(uid.as_i64());
   let favorites = folder.get_my_favorite_sections(uid.as_i64());

--- a/collab-folder/tests/folder_test/replace_view_test.rs
+++ b/collab-folder/tests/folder_test/replace_view_test.rs
@@ -13,20 +13,20 @@ fn replace_view_get_view() {
   let v1 = make_test_view("v1", &workspace_id, vec![]);
   let v21 = make_test_view("v2.1", &workspace_id, vec![]);
   let v22 = make_test_view("v2.2", &workspace_id, vec![]);
-  let v2 = make_test_view("v2", &workspace_id, vec!["v2.1".to_string(), "v2.2".into()]);
+  let v2 = make_test_view("v2", &workspace_id, vec!["v2.1".into(), "v2.2".into()]);
   folder.insert_view(v1, None, uid);
   folder.insert_view(v21, None, uid);
   folder.insert_view(v22, None, uid);
   folder.insert_view(v2, None, uid);
 
   let old = folder.get_view("v2", uid).unwrap();
-  assert_eq!(old.id, "v2");
+  assert_eq!(&*old.id, "v2");
 
-  folder.replace_view("v2", "v3", uid);
+  folder.replace_view(&"v2".into(), &"v3".into(), uid);
 
   // getting old view id should return new one
   let new = folder.get_view("v2", uid).unwrap();
-  assert_eq!(new.id, "v3");
+  assert_eq!(&*new.id, "v3");
   assert_eq!(new.name, old.name);
   assert_eq!(new.parent_view_id, old.parent_view_id);
   assert_eq!(new.children, old.children);
@@ -45,7 +45,7 @@ fn replace_view_get_view_concurrent_update() {
   let v1 = make_test_view("v1", &workspace_id, vec![]);
   let v21 = make_test_view("v2.1", &workspace_id, vec![]);
   let v22 = make_test_view("v2.2", &workspace_id, vec![]);
-  let v2 = make_test_view("v2", &workspace_id, vec!["v2.1".to_string(), "v2.2".into()]);
+  let v2 = make_test_view("v2", &workspace_id, vec!["v2.1".into(), "v2.2".into()]);
   f1.insert_view(v1, None, uid1);
   f1.insert_view(v21, None, uid1);
   f1.insert_view(v22, None, uid1);
@@ -62,10 +62,10 @@ fn replace_view_get_view_concurrent_update() {
   assert_eq!(f1.to_json_value(), f2.to_json_value());
 
   // concurrently replace view in f1 and add new child view in f2
-  f1.replace_view("v2", "v3", uid1);
+  f1.replace_view(&"v2".into(), &"v3".into(), uid1);
 
   let mut v23 = make_test_view("v2.3", &workspace_id, vec![]);
-  v23.parent_view_id = "v2".to_string();
+  v23.parent_view_id = "v2".into();
   f2.insert_view(v23, None, uid2);
 
   // cross-sync state between f1 and f2
@@ -75,9 +75,12 @@ fn replace_view_get_view_concurrent_update() {
     .unwrap();
 
   let v1 = f1.get_view("v2", uid2).unwrap();
-  assert_eq!(v1.id, "v3");
+  assert_eq!(&*v1.id, "v3");
   assert_eq!(
-    v1.children.iter().map(|c| c.id.clone()).collect::<Vec<_>>(),
+    v1.children
+      .iter()
+      .map(|c| c.id.as_ref())
+      .collect::<Vec<_>>(),
     vec!["v2.1", "v2.2", "v2.3"]
   );
 
@@ -96,7 +99,7 @@ fn replace_view_all_views_concurrent_update() {
   let v1 = make_test_view("v1", &workspace_id, vec![]);
   let v21 = make_test_view("v2.1", &workspace_id, vec![]);
   let v22 = make_test_view("v2.2", &workspace_id, vec![]);
-  let v2 = make_test_view("v2", &workspace_id, vec!["v2.1".to_string(), "v2.2".into()]);
+  let v2 = make_test_view("v2", &workspace_id, vec!["v2.1".into(), "v2.2".into()]);
   f1.insert_view(v1, None, uid1);
   f1.insert_view(v21, None, uid1);
   f1.insert_view(v22, None, uid1);
@@ -113,10 +116,10 @@ fn replace_view_all_views_concurrent_update() {
   assert_eq!(f1.to_json_value(), f2.to_json_value());
 
   // concurrently replace view in f1 and add new child view in f2
-  f1.replace_view("v2", "v3", uid1);
+  f1.replace_view(&"v2".into(), &"v3".into(), uid1);
 
   let mut v23 = make_test_view("v2.3", &workspace_id, vec![]);
-  v23.parent_view_id = "v2".to_string();
+  v23.parent_view_id = "v2".into();
   f2.insert_view(v23, None, uid2);
 
   // cross-sync state between f1 and f2

--- a/collab-folder/tests/folder_test/serde_test.rs
+++ b/collab-folder/tests/folder_test/serde_test.rs
@@ -1,7 +1,7 @@
 use collab::core::collab::{CollabOptions, default_client_id};
 use collab::core::origin::CollabOrigin;
 use collab::preclude::{Collab, ReadTxn};
-use collab_folder::{Folder, FolderData, UserId, timestamp};
+use collab_folder::{Folder, FolderData, UserId, ViewId, timestamp};
 use serde_json::json;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -249,14 +249,14 @@ async fn deserialize_folder_data() {
         .get_all_trash_sections(clone_uid.as_i64())
         .into_iter()
         .map(|trash| trash.id)
-        .collect::<Vec<String>>();
+        .collect::<Vec<_>>();
 
       // get the private view ids
       let _private_view_ids = folder
         .get_all_private_sections(clone_uid.as_i64())
         .into_iter()
         .map(|view| view.id)
-        .collect::<Vec<String>>();
+        .collect::<Vec<_>>();
 
       get_view_ids_should_be_filtered(&folder, clone_uid.as_i64());
       let elapsed = start.elapsed();
@@ -272,24 +272,24 @@ async fn deserialize_folder_data() {
   }
 }
 
-fn get_view_ids_should_be_filtered(folder: &Folder, uid: i64) -> Vec<String> {
+fn get_view_ids_should_be_filtered(folder: &Folder, uid: i64) -> Vec<ViewId> {
   let trash_ids = get_all_trash_ids(folder, uid);
   let other_private_view_ids = get_other_private_view_ids(folder, uid);
   [trash_ids, other_private_view_ids].concat()
 }
 
-fn get_other_private_view_ids(folder: &Folder, uid: i64) -> Vec<String> {
+fn get_other_private_view_ids(folder: &Folder, uid: i64) -> Vec<ViewId> {
   let my_private_view_ids = folder
     .get_my_private_sections(uid)
     .into_iter()
     .map(|view| view.id)
-    .collect::<Vec<String>>();
+    .collect::<Vec<_>>();
 
   let all_private_view_ids = folder
     .get_all_private_sections(uid)
     .into_iter()
     .map(|view| view.id)
-    .collect::<Vec<String>>();
+    .collect::<Vec<_>>();
 
   all_private_view_ids
     .into_iter()
@@ -297,12 +297,12 @@ fn get_other_private_view_ids(folder: &Folder, uid: i64) -> Vec<String> {
     .collect()
 }
 
-fn get_all_trash_ids(folder: &Folder, uid: i64) -> Vec<String> {
+fn get_all_trash_ids(folder: &Folder, uid: i64) -> Vec<ViewId> {
   let trash_ids = folder
     .get_all_trash_sections(uid)
     .into_iter()
     .map(|trash| trash.id)
-    .collect::<Vec<String>>();
+    .collect::<Vec<_>>();
   let mut all_trash_ids = trash_ids.clone();
   let txn = folder.collab.transact();
   for trash_id in trash_ids {
@@ -316,14 +316,14 @@ fn get_all_child_view_ids<T: ReadTxn>(
   txn: &T,
   view_id: &str,
   uid: i64,
-) -> Vec<String> {
+) -> Vec<ViewId> {
   let child_view_ids = folder
     .body
     .views
     .get_views_belong_to(txn, view_id, uid)
     .into_iter()
     .map(|view| view.id.clone())
-    .collect::<Vec<String>>();
+    .collect::<Vec<_>>();
   let mut all_child_view_ids = child_view_ids.clone();
   for child_view_id in child_view_ids {
     all_child_view_ids.extend(get_all_child_view_ids(folder, txn, &child_view_id, uid));

--- a/collab-folder/tests/folder_test/trash_test.rs
+++ b/collab-folder/tests/folder_test/trash_test.rs
@@ -26,9 +26,9 @@ fn create_trash_test() {
 
   let trash = folder.get_my_trash_sections(uid.as_i64());
   assert_eq!(trash.len(), 3);
-  assert_eq!(trash[0].id, "v1");
-  assert_eq!(trash[1].id, "v2");
-  assert_eq!(trash[2].id, "v3");
+  assert_eq!(&*trash[0].id, "v1");
+  assert_eq!(&*trash[1].id, "v2");
+  assert_eq!(&*trash[2].id, "v3");
 }
 
 #[test]
@@ -46,12 +46,12 @@ fn delete_trash_view_ids_test() {
   folder.add_trash_view_ids(vec!["v1".to_string(), "v2".to_string()], uid.as_i64());
 
   let trash = folder.get_my_trash_sections(uid.as_i64());
-  assert_eq!(trash[0].id, "v1");
-  assert_eq!(trash[1].id, "v2");
+  assert_eq!(&*trash[0].id, "v1");
+  assert_eq!(&*trash[1].id, "v2");
 
   folder.delete_trash_view_ids(vec!["v1".to_string()], uid.as_i64());
   let trash = folder.get_my_trash_sections(uid.as_i64());
-  assert_eq!(trash[0].id, "v2");
+  assert_eq!(&*trash[0].id, "v2");
 }
 
 #[tokio::test]
@@ -68,7 +68,7 @@ async fn create_trash_callback_test() {
   timeout(poll_tx(section_rx, |change| match change {
     SectionChange::Trash(change) => match change {
       TrashSectionChange::TrashItemAdded { ids } => {
-        assert_eq!(ids, vec!["1", "2"]);
+        assert_eq!(ids, vec!["1".into(), "2".into()]);
       },
       TrashSectionChange::TrashItemRemoved { .. } => {},
     },
@@ -89,10 +89,10 @@ async fn delete_trash_view_ids_callback_test() {
   timeout(poll_tx(trash_rx, |change| match change {
     SectionChange::Trash(change) => match change {
       TrashSectionChange::TrashItemAdded { ids } => {
-        assert_eq!(ids, vec!["1", "2"]);
+        assert_eq!(ids, vec!["1".into(), "2".into()]);
       },
       TrashSectionChange::TrashItemRemoved { ids } => {
-        assert_eq!(ids, vec!["1", "2"]);
+        assert_eq!(ids, vec!["1".into(), "2".into()]);
       },
     },
   }))

--- a/collab-folder/tests/folder_test/util.rs
+++ b/collab-folder/tests/folder_test/util.rs
@@ -31,7 +31,7 @@ pub struct FolderTest {
 }
 
 pub fn create_folder(uid: UserId, workspace_id: &str) -> FolderTest {
-  let mut workspace = Workspace::new(workspace_id.to_string(), "".to_string(), uid.as_i64());
+  let mut workspace = Workspace::new(workspace_id.into(), "".to_string(), uid.as_i64());
   workspace.created_at = 0;
   let folder_data = FolderData::new(uid.as_i64(), workspace);
   create_folder_with_data(uid, workspace_id, folder_data)
@@ -83,14 +83,14 @@ pub fn create_folder_with_workspace(uid: UserId, workspace_id: &str) -> FolderTe
   create_folder(uid, workspace_id)
 }
 
-pub fn make_test_view(view_id: &str, parent_view_id: &str, belongings: Vec<String>) -> View {
+pub fn make_test_view(view_id: &str, parent_view_id: &str, belongings: Vec<ViewId>) -> View {
   let belongings = belongings
     .into_iter()
     .map(ViewIdentifier::new)
     .collect::<Vec<ViewIdentifier>>();
   View {
-    id: view_id.to_string(),
-    parent_view_id: parent_view_id.to_string(),
+    id: view_id.into(),
+    parent_view_id: parent_view_id.into(),
     name: "".to_string(),
     children: RepeatedViewIdentifier::new(belongings),
     created_at: 0,

--- a/collab-folder/tests/folder_test/view_test.rs
+++ b/collab-folder/tests/folder_test/view_test.rs
@@ -96,9 +96,9 @@ fn delete_view_test() {
     .body
     .views
     .get_views(&txn, &["v1", "v2", "v3"], uid.as_i64());
-  assert_eq!(views[0].id, "v1");
-  assert_eq!(views[1].id, "v2");
-  assert_eq!(views[2].id, "v3");
+  assert_eq!(&*views[0].id, "v1");
+  assert_eq!(&*views[1].id, "v2");
+  assert_eq!(&*views[2].id, "v3");
 
   folder
     .body
@@ -320,7 +320,7 @@ fn dissociate_and_associate_view_test() {
   let mut txn = folder.collab.transact_mut();
 
   let view_1_child = make_test_view(view_1_child_id, view_1_id, vec![]);
-  let view_1 = make_test_view(view_1_id, workspace_id, vec![view_1_child_id.to_string()]);
+  let view_1 = make_test_view(view_1_id, workspace_id, vec![view_1_child_id.into()]);
   let view_2 = make_test_view(view_2_id, workspace_id, vec![]);
   folder
     .body
@@ -379,8 +379,8 @@ fn dissociate_and_associate_view_test() {
     .get_view(&txn, view_1_id, uid.as_i64())
     .unwrap();
   assert_eq!(r_view.children.items.iter().len(), 2);
-  assert_eq!(r_view.children.items.first().unwrap().id, view_2_id);
-  assert_eq!(r_view.children.items.get(1).unwrap().id, view_1_child_id);
+  assert_eq!(&*r_view.children.items.first().unwrap().id, view_2_id);
+  assert_eq!(&*r_view.children.items.get(1).unwrap().id, view_1_child_id);
 
   folder
     .body
@@ -397,7 +397,7 @@ fn dissociate_and_associate_view_test() {
     &mut txn,
     view_1_id,
     view_2_id,
-    Some(view_1_child_id.to_string()),
+    Some(view_1_child_id.into()),
   );
 
   let r_view = folder
@@ -406,8 +406,8 @@ fn dissociate_and_associate_view_test() {
     .get_view(&txn, view_1_id, uid.as_i64())
     .unwrap();
   assert_eq!(r_view.children.items.iter().len(), 2);
-  assert_eq!(r_view.children.items.first().unwrap().id, view_1_child_id);
-  assert_eq!(r_view.children.items.get(1).unwrap().id, view_2_id);
+  assert_eq!(&*r_view.children.items.first().unwrap().id, view_1_child_id);
+  assert_eq!(&*r_view.children.items.get(1).unwrap().id, view_2_id);
 }
 
 #[test]
@@ -422,7 +422,7 @@ fn move_view_across_parent_test() {
   let mut folder = folder_test.folder;
 
   let view_1_child = make_test_view(view_1_child_id, view_1_id, vec![]);
-  let view_1 = make_test_view(view_1_id, workspace_id, vec![view_1_child_id.to_string()]);
+  let view_1 = make_test_view(view_1_id, workspace_id, vec![view_1_child_id.into()]);
   let view_2 = make_test_view(view_2_id, workspace_id, vec![]);
   folder.insert_view(view_1_child, None, uid.as_i64());
   folder.insert_view(view_1, None, uid.as_i64());
@@ -438,7 +438,7 @@ fn move_view_across_parent_test() {
   let view_1_child = folder.get_view(view_1_child_id, uid.as_i64()).unwrap();
   assert_eq!(view_1.children.items.iter().len(), 0);
   assert_eq!(view_2.children.items.iter().len(), 1);
-  assert_eq!(view_1_child.parent_view_id, view_2_id);
+  assert_eq!(&*view_1_child.parent_view_id, view_2_id);
 
   // Move view_1_child from view_2 to current workspace
   folder.move_nested_view(view_1_child_id, workspace_id, None, uid.as_i64());
@@ -450,10 +450,10 @@ fn move_view_across_parent_test() {
     .unwrap();
   assert_eq!(view_1.children.items.iter().len(), 0);
   assert_eq!(view_2.children.items.iter().len(), 0);
-  assert_eq!(view_1_child.parent_view_id, workspace_id);
+  assert_eq!(&*view_1_child.parent_view_id, workspace_id);
   assert_eq!(workspace.child_views.items.len(), 3);
   assert_eq!(
-    workspace.child_views.items.first().unwrap().id,
+    &*workspace.child_views.items.first().unwrap().id,
     view_1_child_id
   );
 
@@ -461,7 +461,7 @@ fn move_view_across_parent_test() {
   folder.move_nested_view(
     view_1_child_id,
     workspace_id,
-    Some(view_1_id.to_string()),
+    Some(view_1_id.into()),
     uid.as_i64(),
   );
   let view_1 = folder.get_view(view_1_id, uid.as_i64()).unwrap();
@@ -472,13 +472,13 @@ fn move_view_across_parent_test() {
     .unwrap();
   assert_eq!(view_1.children.items.iter().len(), 0);
   assert_eq!(view_2.children.items.iter().len(), 0);
-  assert_eq!(view_1_child.parent_view_id, workspace_id);
+  assert_eq!(&*view_1_child.parent_view_id, workspace_id);
   assert_eq!(workspace.child_views.items.len(), 3);
   assert_eq!(
-    workspace.child_views.items.get(1).unwrap().id,
+    &*workspace.child_views.items.get(1).unwrap().id,
     view_1_child_id
   );
-  assert_eq!(workspace.child_views.items.first().unwrap().id, view_1_id);
+  assert_eq!(&*workspace.child_views.items.first().unwrap().id, view_1_id);
 
   // move view_1_child from current workspace to view_1
   folder.move_nested_view(view_1_child_id, view_1_id, None, uid.as_i64());
@@ -489,8 +489,8 @@ fn move_view_across_parent_test() {
     .get_workspace_info(workspace_id, uid.as_i64())
     .unwrap();
   assert_eq!(view_1.children.items.iter().len(), 1);
-  assert_eq!(view_1.children.items.first().unwrap().id, view_1_child_id);
-  assert_eq!(view_1_child.parent_view_id, view_1_id);
+  assert_eq!(&*view_1.children.items.first().unwrap().id, view_1_child_id);
+  assert_eq!(&*view_1_child.parent_view_id, view_1_id);
   assert_eq!(view_2.children.items.iter().len(), 0);
   assert_eq!(workspace.child_views.items.len(), 2);
 }

--- a/collab-folder/tests/folder_test/workspace_test.rs
+++ b/collab-folder/tests/folder_test/workspace_test.rs
@@ -8,7 +8,7 @@ fn test_workspace_is_ready() {
   let uid = UserId::from(1);
   let object_id = "1";
 
-  let workspace = Workspace::new("w1".to_string(), "".to_string(), uid.as_i64());
+  let workspace = Workspace::new("w1".into(), "".to_string(), uid.as_i64());
   let folder_data = FolderData::new(uid.as_i64(), workspace);
   let options = CollabOptions::new(object_id.to_string(), default_client_id());
   let collab = Collab::new_with_options(CollabOrigin::Empty, options).unwrap();

--- a/collab-importer/src/notion/importer.rs
+++ b/collab-importer/src/notion/importer.rs
@@ -209,7 +209,7 @@ impl ImportedInfo {
       Box::pin(combined_stream) as ImportedCollabInfoStream
     } else {
       let imported_space_collab = ImportedCollab {
-        object_id: self.space_view.view.id.clone(),
+        object_id: self.space_view.view.id.to_string(),
         collab_type: CollabType::Document,
         encoded_collab: self
           .space_collab
@@ -221,7 +221,7 @@ impl ImportedInfo {
         name: self.name.clone(),
         imported_collabs: vec![imported_space_collab],
         resources: vec![CollabResource {
-          object_id: self.space_view.view.id,
+          object_id: self.space_view.view.id.to_string(),
           files: vec![],
         }],
         import_type: ImportType::Document,

--- a/collab-importer/src/space_view.rs
+++ b/collab-importer/src/space_view.rs
@@ -26,7 +26,7 @@ pub fn create_space_view(
   let collab = Collab::new_with_options(CollabOrigin::Empty, options)
     .map_err(|err| ImporterError::Internal(err.into()))?;
 
-  let view = NestedChildViewBuilder::new(uid, workspace_id.to_string())
+  let view = NestedChildViewBuilder::new(uid, workspace_id.into())
     .with_view_id(view_id)
     .with_layout(ViewLayout::Document)
     .with_name(name)

--- a/collab-importer/src/workspace/folder_collab_remapper.rs
+++ b/collab-importer/src/workspace/folder_collab_remapper.rs
@@ -63,8 +63,8 @@ impl FolderCollabRemapper {
         .collect();
 
       let mut view = View::new(
-        new_view_id.clone(),
-        new_parent_id,
+        new_view_id.into(),
+        new_parent_id.into(),
         view_metadata.name.clone(),
         view_metadata.layout.clone(),
         Some(uid),
@@ -80,7 +80,7 @@ impl FolderCollabRemapper {
 
     folder_data.views = views;
     folder_data.workspace = Workspace {
-      id: new_workspace_id.clone(),
+      id: new_workspace_id.into(),
       name: workspace_name.to_string(),
       child_views: RepeatedViewIdentifier::new(top_level_view_ids),
       created_at: current_time,
@@ -89,7 +89,7 @@ impl FolderCollabRemapper {
       last_edited_by: Some(uid),
     };
 
-    let options = CollabOptions::new(new_workspace_id.clone(), default_client_id());
+    let options = CollabOptions::new(new_workspace_id.into(), default_client_id());
     let collab = Collab::new_with_options(CollabOrigin::Empty, options).unwrap();
     let folder = Folder::create(collab, None, folder_data);
     Ok(folder)

--- a/collab-importer/src/workspace/folder_collab_remapper.rs
+++ b/collab-importer/src/workspace/folder_collab_remapper.rs
@@ -20,28 +20,25 @@ impl FolderCollabRemapper {
   ) -> Result<Folder> {
     let new_workspace_id = id_mapper
       .get_new_id(&relation_map.workspace_id)
-      .ok_or_else(|| anyhow!("missing mapping for workspace id"))?
-      .clone();
+      .ok_or_else(|| anyhow!("missing mapping for workspace id"))?;
 
     let current_time = timestamp();
 
-    let mut folder_data = default_folder_data(uid, &new_workspace_id);
+    let mut folder_data = default_folder_data(uid, new_workspace_id);
     let mut views = vec![];
     let mut top_level_view_ids = vec![];
 
     for (old_view_id, view_metadata) in &relation_map.views {
       let new_view_id = id_mapper
         .get_new_id(old_view_id)
-        .ok_or_else(|| anyhow!("missing mapping for view id: {}", old_view_id))?
-        .clone();
+        .ok_or_else(|| anyhow!("missing mapping for view id: {}", old_view_id))?;
 
       let new_parent_id = if let Some(old_parent_id) = &view_metadata.parent_id {
         id_mapper
           .get_new_id(old_parent_id)
           .ok_or_else(|| anyhow!("missing mapping for parent id: {}", old_parent_id))?
-          .clone()
       } else {
-        new_workspace_id.clone()
+        new_workspace_id
       };
 
       if view_metadata
@@ -49,17 +46,13 @@ impl FolderCollabRemapper {
         .as_ref()
         .is_none_or(|pid| pid == &relation_map.workspace_id)
       {
-        top_level_view_ids.push(ViewIdentifier::new(new_view_id.clone()));
+        top_level_view_ids.push(ViewIdentifier::new(new_view_id));
       }
 
       let children_ids: Vec<ViewIdentifier> = view_metadata
         .children
         .iter()
-        .filter_map(|child_id| {
-          id_mapper
-            .get_new_id(child_id)
-            .map(|new_id| ViewIdentifier::new(new_id.clone()))
-        })
+        .filter_map(|child_id| id_mapper.get_new_id(child_id).map(ViewIdentifier::new))
         .collect();
 
       let mut view = View::new(

--- a/collab-importer/src/workspace/id_mapper.rs
+++ b/collab-importer/src/workspace/id_mapper.rs
@@ -68,8 +68,8 @@ impl IdMapper {
     Self { id_map }
   }
 
-  pub fn get_new_id(&self, old_id: &str) -> Option<&String> {
-    self.id_map.get(old_id)
+  pub fn get_new_id(&self, old_id: &str) -> Option<&str> {
+    Some(self.id_map.get(old_id)?.as_str())
   }
 
   pub fn generate_new_id(&self) -> String {

--- a/collab-importer/tests/workspace/folder_collab_remapper.rs
+++ b/collab-importer/tests/workspace/folder_collab_remapper.rs
@@ -74,7 +74,7 @@ async fn test_folder_collab_remapper() {
   assert_eq!(all_views.len(), relation_map.views.len() + 1);
 
   for view in &all_views {
-    if &*view.id == workspace_id {
+    if *view.id == workspace_id {
       continue;
     }
 

--- a/collab-importer/tests/workspace/folder_collab_remapper.rs
+++ b/collab-importer/tests/workspace/folder_collab_remapper.rs
@@ -19,7 +19,7 @@ fn verify_view(
   let view = folder.get_view(new_id, uid).unwrap();
 
   assert_eq!(view.name, expected_name);
-  assert_eq!(view.parent_view_id, expected_parent_id);
+  assert_eq!(&*view.parent_view_id, expected_parent_id);
   assert_eq!(view.children.len(), expected_children_len);
   assert_eq!(view.layout, expected_layout);
 }
@@ -55,7 +55,7 @@ async fn test_folder_collab_remapper() {
 
   let workspace_info = folder.get_workspace_info(&workspace_id, uid).unwrap();
   assert_eq!(workspace_info.name, "My Custom Workspace");
-  assert_eq!(workspace_info.id, workspace_id);
+  assert_eq!(&*workspace_info.id, workspace_id);
 
   let top_level_views_count = relation_map
     .views
@@ -74,14 +74,14 @@ async fn test_folder_collab_remapper() {
   assert_eq!(all_views.len(), relation_map.views.len() + 1);
 
   for view in &all_views {
-    if view.id == workspace_id {
+    if &*view.id == workspace_id {
       continue;
     }
 
     let old_view_id = relation_map
       .views
       .keys()
-      .find(|old_id| id_mapper.get_new_id(old_id) == Some(&view.id))
+      .find(|old_id| id_mapper.get_new_id(old_id) == Some(&*view.id))
       .expect("mapped view should exist in original relation map");
 
     let original_view = &relation_map.views[old_view_id];
@@ -96,15 +96,15 @@ async fn test_folder_collab_remapper() {
 
     if let Some(original_parent_id) = &original_view.parent_id {
       let expected_parent_id = id_mapper.get_new_id(original_parent_id).unwrap();
-      assert_eq!(view.parent_view_id, *expected_parent_id);
+      assert_eq!(&*view.parent_view_id, expected_parent_id);
     } else {
-      assert_eq!(view.parent_view_id, workspace_id);
+      assert_eq!(&*view.parent_view_id, workspace_id);
     }
 
     assert_eq!(view.children.len(), original_view.children.len());
     for (i, child) in view.children.iter().enumerate() {
       let expected_child_id = id_mapper.get_new_id(&original_view.children[i]).unwrap();
-      assert_eq!(child.id, *expected_child_id);
+      assert_eq!(&*child.id, expected_child_id);
     }
   }
 }

--- a/collab-importer/tests/workspace/workspace_remapper_test.rs
+++ b/collab-importer/tests/workspace/workspace_remapper_test.rs
@@ -44,7 +44,7 @@ async fn test_workspace_remapper_folder_structure() {
   let workspace_info = folder.get_workspace_info(&workspace_id, uid).unwrap();
 
   assert_eq!(workspace_info.name, workspace_name);
-  assert_eq!(workspace_info.id, workspace_id);
+  assert_eq!(&*workspace_info.id, workspace_id);
 
   let all_views = folder.get_all_views(uid);
   assert_eq!(all_views.len(), 8);

--- a/collab/src/any_mut.rs
+++ b/collab/src/any_mut.rs
@@ -9,7 +9,7 @@ pub enum AnyMut {
   Bool(bool),
   Number(f64),
   BigInt(i64),
-  String(String),
+  String(Arc<str>),
   Bytes(bytes::BytesMut),
   Array(Vec<AnyMut>),
   Map(HashMap<String, AnyMut>),
@@ -23,7 +23,7 @@ impl From<Any> for AnyMut {
       Any::Bool(bool) => AnyMut::Bool(bool),
       Any::Number(num) => AnyMut::Number(num),
       Any::BigInt(num) => AnyMut::BigInt(num),
-      Any::String(str) => AnyMut::String(str.to_string()),
+      Any::String(str) => AnyMut::String(str.clone()),
       Any::Buffer(buf) => AnyMut::Bytes(bytes::BytesMut::from(&*buf)),
       Any::Array(array) => {
         let array: Vec<AnyMut> = array.iter().map(|any| AnyMut::from(any.clone())).collect();

--- a/collab/src/any_mut.rs
+++ b/collab/src/any_mut.rs
@@ -48,7 +48,7 @@ impl From<AnyMut> for Any {
       AnyMut::Bool(bool) => Any::Bool(bool),
       AnyMut::Number(num) => Any::Number(num),
       AnyMut::BigInt(num) => Any::BigInt(num),
-      AnyMut::String(str) => Any::String(str.into()),
+      AnyMut::String(str) => Any::String(str),
       AnyMut::Bytes(bytes) => Any::Buffer(bytes.freeze().to_vec().into()),
       AnyMut::Array(array) => Any::Array(array.into_iter().map(Any::from).collect()),
       AnyMut::Map(map) => {


### PR DESCRIPTION
This PR replaced view ID type from `String` into dedicated `ViewId` alias (which under the hood is `Arc<str>`). The reason is that in many cases we're cross referencing views by IDs all over the place (ID mappings, parent-child relations etc.), doing a lot of string copying (which in Rust means deep copy, together with contents). Using Arc is much simpler, faster and occupies less space.